### PR TITLE
supporting api level 10 in getScreenshot

### DIFF
--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/model/DefaultSelendroidDriver.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/model/DefaultSelendroidDriver.java
@@ -205,7 +205,12 @@ public class DefaultSelendroidDriver implements SelendroidDriver {
           Display display =
               serverInstrumentation.getCurrentActivity().getWindowManager().getDefaultDisplay();
           Point size = new Point();
-          display.getSize(size);
+          try {
+            display.getSize(size);
+          } catch (NoSuchMethodError ignore) { // Older than api level 13
+            size.x = display.getWidth();
+            size.y = display.getHeight();
+          }
 
           // Get root view
           View view = mainView.getRootView();


### PR DESCRIPTION
looks like the min version of the android api is supposed to be 10 (I might want to try for 8, that's what my team currently uses as the 'oldest' version to test).

getSize was introduced in api level 13
