### PR TITLE
should be throwing stale reference exception

### DIFF
--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/DoubleTapOnElement.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/DoubleTapOnElement.java
@@ -34,9 +34,9 @@ public class DoubleTapOnElement extends RequestHandler {
     SelendroidLogger.log("double tap on element gesture");
     Long elementId = getElementId();
     TouchScreen touchScreen = getSelendroidDriver().getTouch();
-    AndroidElement element = getKnownElements().get(elementId);
+    AndroidElement element = getElementFromCache(elementId);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '"
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '"
           + elementId + "' was not found."));
     }
     Coordinates elementLocation = element.getCoordinates();

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/Flick.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/Flick.java
@@ -41,9 +41,9 @@ public class Flick extends RequestHandler {
       int xOffset = payload.getInt("xoffset");
       int yOffset = payload.getInt("yoffset");
       int speed = payload.getInt("speed");
-      AndroidElement element = getKnownElements().get(elementId);
+      AndroidElement element = getElementFromCache(elementId);
       if (element == null) {
-        return new Response(getSessionId(), 7, new SelendroidException("Element with id '"
+        return new Response(getSessionId(), 10, new SelendroidException("Element with id '"
             + elementId + "' was not found."));
       }
       Coordinates elementLocation = element.getCoordinates();

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementAttribute.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementAttribute.java
@@ -35,7 +35,7 @@ public class GetElementAttribute extends RequestHandler {
     String attributeName = getNameAttribute();
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '" + id
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '" + id
           + "' was not found."));
     }
     String text = null;

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementDisplayed.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementDisplayed.java
@@ -21,7 +21,7 @@ public class GetElementDisplayed extends RequestHandler {
 
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '" + id
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '" + id
           + "' was not found."));
     }
     return new Response(getSessionId(), element.isDisplayed());

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementEnabled.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementEnabled.java
@@ -21,8 +21,8 @@ public class GetElementEnabled extends RequestHandler {
 
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '" + id
-          + "' was not found."));
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '" + id
+          + "' was not found in cache."));
     }
     return new Response(getSessionId(), element.isEnabled());
   }

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementSelected.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementSelected.java
@@ -21,7 +21,7 @@ public class GetElementSelected extends RequestHandler {
 
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '" + id
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '" + id
           + "' was not found."));
     }
     boolean selected=element.isSelected();

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementSize.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetElementSize.java
@@ -36,7 +36,7 @@ public class GetElementSize extends RequestHandler {
 
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '" + id
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '" + id
           + "' was not found."));
     }
     Dimension dimension = element.getSize();

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetText.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/GetText.java
@@ -34,7 +34,7 @@ public class GetText extends RequestHandler {
 
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '"
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '"
           + id + "' was not found."));
     }
     String text = element.getText();

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/LogElement.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/LogElement.java
@@ -35,11 +35,11 @@ public class LogElement extends RequestHandler {
 
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '" + id
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '" + id
           + "' was not found."));
     }
     if (element instanceof AndroidWebElement) {
-      return new Response(getSessionId(), 7, new SelendroidException(
+      return new Response(getSessionId(), 12, new SelendroidException(
           "Get source of element is only supported for native elements."));
     }
 

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/LongPressOnElement.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/LongPressOnElement.java
@@ -35,7 +35,7 @@ public class LongPressOnElement extends RequestHandler {
 
     AndroidElement element = getElementFromCache(elementId);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '"
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '"
           + elementId + "' was not found."));
     }
 

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/Scroll.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/Scroll.java
@@ -38,7 +38,7 @@ public class Scroll extends RequestHandler {
     } else {
       AndroidElement element = getElementFromCache(elementId);
       if (element == null) {
-        return new Response(getSessionId(), 7, new SelendroidException("Element with id '"
+        return new Response(getSessionId(), 10, new SelendroidException("Element with id '"
             + elementId + "' was not found."));
       }
       getSelendroidDriver().getTouch().scroll(element.getCoordinates(), xoffset, yoffset);

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/SendKeys.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/SendKeys.java
@@ -34,7 +34,7 @@ public class SendKeys extends RequestHandler {
 
     AndroidElement element = getElementFromCache(id);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '" + id
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '" + id
           + "' was not found."));
     }
     String[] keysToSend = null;

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/SingleTapOnElement.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/SingleTapOnElement.java
@@ -36,7 +36,7 @@ public class SingleTapOnElement extends RequestHandler {
 
     AndroidElement element = getElementFromCache(elementId);
     if (element == null) {
-      return new Response(getSessionId(), 7, new SelendroidException("Element with id '"
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '"
           + elementId + "' was not found."));
     }
     TouchScreen touchScreen = getSelendroidDriver().getTouch();

--- a/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/SubmitForm.java
+++ b/selendroid-server/src/main/java/org/openqa/selendroid/server/handler/SubmitForm.java
@@ -16,6 +16,7 @@ package org.openqa.selendroid.server.handler;
 import org.json.JSONException;
 import org.openqa.selendroid.server.RequestHandler;
 import org.openqa.selendroid.server.Response;
+import org.openqa.selendroid.server.exceptions.SelendroidException;
 import org.openqa.selendroid.server.model.AndroidElement;
 import org.openqa.selendroid.util.SelendroidLogger;
 import org.webbitserver.HttpRequest;
@@ -31,12 +32,16 @@ public class SubmitForm extends RequestHandler {
     SelendroidLogger.log("Submit element command");
     Long id = getElementId();
     AndroidElement element = getElementFromCache(id);
+    if (element == null) {
+      return new Response(getSessionId(), 10, new SelendroidException("Element with id '"
+          + id + "' was not found."));
+    }
     String sessionId = getSessionId();
     try {
       element.submit();
     } catch (Exception e) {
       SelendroidLogger.log("error while submitting the element: ", e);
-      return new Response(sessionId, 33, e);
+      return new Response(sessionId, 13, e);
     }
     return new Response(sessionId, "");
   }


### PR DESCRIPTION
So, I am able to locally build it now :) Thanks for the help there. (sorry about the last pull, i really thought i compiled that!!)

Although this code is a first step towards stale reference exceptions, it doesn't actually work... because the cache doesn't ever seem to get invalidated. Is it not valid to find an element, click on it (which loads a new view without that element on it anymore) and that element to get purged or invalidated in the cache? Maybe this way only works for WebElements.
Waiting for the element to become invisible is a work-around for this for me.

I'll try to look at the tests in the near future (and update them if I have broken anything with this change)
