### PR TITLE
Fix to findElements by view tag name

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
@@ -13,6 +13,27 @@
  */
 package io.selendroid.server.model;
 
+import io.selendroid.ServerInstrumentation;
+import io.selendroid.android.AndroidTouchScreen;
+import io.selendroid.android.AndroidWait;
+import io.selendroid.android.KeySender;
+import io.selendroid.android.ViewHierarchyAnalyzer;
+import io.selendroid.android.WindowType;
+import io.selendroid.exceptions.NoSuchElementException;
+import io.selendroid.exceptions.SelendroidException;
+import io.selendroid.exceptions.UnsupportedOperationException;
+import io.selendroid.server.Session;
+import io.selendroid.server.model.internal.AbstractNativeElementContext;
+import io.selendroid.server.model.internal.AbstractWebElementContext;
+import io.selendroid.server.model.internal.execute_native.FindElementByAndroidTag;
+import io.selendroid.server.model.internal.execute_native.FindRId;
+import io.selendroid.server.model.internal.execute_native.GetL10nKeyTranslation;
+import io.selendroid.server.model.internal.execute_native.InvokeMenuAction;
+import io.selendroid.server.model.internal.execute_native.NativeExecuteScript;
+import io.selendroid.server.model.js.AndroidAtoms;
+import io.selendroid.util.Preconditions;
+import io.selendroid.util.SelendroidLogger;
+
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -26,28 +47,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import io.selendroid.ServerInstrumentation;
-import io.selendroid.android.AndroidWait;
-import io.selendroid.android.KeySender;
-import io.selendroid.android.ViewHierarchyAnalyzer;
-import io.selendroid.android.WindowType;
-import io.selendroid.server.model.internal.AbstractNativeElementContext;
-import io.selendroid.server.model.internal.AbstractWebElementContext;
-import io.selendroid.server.model.internal.execute_native.GetL10nKeyTranslation;
-import io.selendroid.server.model.internal.execute_native.NativeExecuteScript;
-import io.selendroid.util.SelendroidLogger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.android.AndroidTouchScreen;
-import io.selendroid.exceptions.NoSuchElementException;
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.UnsupportedOperationException;
-import io.selendroid.server.Session;
-import io.selendroid.server.model.internal.execute_native.FindRId;
-import io.selendroid.server.model.internal.execute_native.InvokeMenuAction;
-import io.selendroid.server.model.js.AndroidAtoms;
-import io.selendroid.util.Preconditions;
 
 import android.app.Activity;
 import android.content.res.Resources.Theme;
@@ -378,6 +380,8 @@ public class DefaultSelendroidDriver implements SelendroidDriver {
     nativeExecuteScriptMap.put("findRId", new FindRId(serverInstrumentation));
     nativeExecuteScriptMap.put("getL10nKeyTranslation", new GetL10nKeyTranslation(
         serverInstrumentation));
+    nativeExecuteScriptMap.put("findElementByAndroidTag", new FindElementByAndroidTag(
+    		session.getKnownElements(),serverInstrumentation));
 
     return session.getSessionId();
   }

--- a/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
@@ -280,10 +280,7 @@ public abstract class AbstractNativeElementContext
     }
 
     public boolean apply(View view) {
-    	if (view.getTag()!=null) {
-   		 return view.getTag().toString().equals(tag);
-   	}
-    return false;
+    	return view.getClass().getSimpleName().equals(tag);
     }
   }
 

--- a/selendroid-server/src/main/java/io/selendroid/server/model/internal/execute_native/FindElementByAndroidTag.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/internal/execute_native/FindElementByAndroidTag.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013 selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model.internal.execute_native;
+
+import io.selendroid.ServerInstrumentation;
+import io.selendroid.android.ViewHierarchyAnalyzer;
+import io.selendroid.server.model.AndroidNativeElement;
+import io.selendroid.server.model.KnownElements;
+import io.selendroid.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.view.View;
+
+/**
+ * This class contains the functionality to find an Android view with the tag name assigned to it
+ * sample usage : WebElement element = (WebElement)webDriver.executeScript("findElementByAndroidTag", "view_test_tag");
+ *
+ */
+
+public class FindElementByAndroidTag implements NativeExecuteScript {
+
+  private ServerInstrumentation serverInstrumentation;
+  protected ViewHierarchyAnalyzer viewAnalyzer;
+  private KnownElements knownElements;
+
+  public FindElementByAndroidTag(KnownElements knownElements, ServerInstrumentation serverInstrumentation) {
+    this.serverInstrumentation = serverInstrumentation;
+    this.knownElements = knownElements;
+    this.viewAnalyzer = ViewHierarchyAnalyzer.getDefaultInstance();
+  }
+  
+
+  @Override
+  public Object executeScript(JSONArray args) {
+	  String tagName = null;
+	  JSONObject result = new JSONObject();
+	  try {
+		  tagName = args.getString(0);
+		  Collection<View> currentViews = viewAnalyzer.getViews(getTopLevelViews());
+		  for (View view : currentViews) {
+				  Object tag = view.getTag();
+				  if (tag!=null && tag.toString().equalsIgnoreCase(tagName)) {
+					  AndroidNativeElement element =  newAndroidElement(view);
+			    	  result.put("ELEMENT", knownElements.getIdOfElement(element));
+			  }
+		  }
+	    } catch (JSONException e) {
+	      e.printStackTrace();
+	    }
+	  return result;
+  }
+
+
+
+private AndroidNativeElement newAndroidElement(View view) {
+    Preconditions.checkNotNull(view);
+    if (knownElements.hasElement(new Long(view.getId()))) {
+      AndroidNativeElement element =
+          (AndroidNativeElement) knownElements.get(new Long(view.getId()));
+      if (element.getView().equals(view)) {
+        return element;
+      }
+    }
+    AndroidNativeElement e = new AndroidNativeElement(view, serverInstrumentation, knownElements);
+    knownElements.add(e);
+    return e;
+  }
+
+protected List<View> getTopLevelViews() {
+    List<View> views = new ArrayList<View>();
+    views.addAll(viewAnalyzer.getTopLevelViews());
+    if (serverInstrumentation.getCurrentActivity() != null
+        && serverInstrumentation.getCurrentActivity().getCurrentFocus() != null) {
+      views.add(serverInstrumentation.getCurrentActivity().getCurrentFocus());
+    }
+    return views;
+  }
+
+
+}


### PR DESCRIPTION
I have made the changes to find the elements based on the View tag names assigned to them.
I have modified  findElementByTagName for this fix ,as the current behaviour of it seems to be to similar to findByClassName . If it is not the case , could you please let me know the best place to fit this solution in,  so that I can change it accordingly.

Swapna
