### PR TITLE
Terminate adb connection only when flag is set. Also correctly add devices when they are already in the list.

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
@@ -63,6 +63,9 @@ public class SelendroidConfiguration {
    
     @Parameter(description = "host of the node. Ip address needs to be specified for registering to a grid hub (guessing can be wrong complex).", names = "-host")
     private String serverHost;
+
+	@Parameter(names = "-keepAdbAlive", description = "If true, adb will not be terminated on server shutdown.")
+	private boolean keepAdbAlive = false;
 	
 	public void setKeystore(String keystore) {
 		this.keystore = keystore;
@@ -180,5 +183,13 @@ public class SelendroidConfiguration {
 
   public void setEmulatorOptions(String qemu) {
     this.emulatorOptions = qemu;
+  }
+
+  public boolean shouldKeepAdbAlive() {
+  	return keepAdbAlive;
+  }
+
+  public void setShouldKeepAdbAlive(boolean keepAdbAlive) {
+  	this.keepAdbAlive = keepAdbAlive;
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
@@ -141,7 +141,8 @@ public class SelendroidStandaloneDriver implements ServerDetails {
     if (hardwareDeviceListener == null) {
       hardwareDeviceListener = new DefaultHardwareDeviceListener(deviceStore);
     }
-    hardwareDeviceManager = new DefaultDeviceManager(AndroidSdk.adb().getAbsolutePath());
+    hardwareDeviceManager = new DefaultDeviceManager(AndroidSdk.adb().getAbsolutePath(),
+      serverConfiguration.shouldKeepAdbAlive());
     hardwareDeviceManager.initialize(hardwareDeviceListener);
 
     List<AndroidEmulator> emulators = DefaultAndroidEmulator.listAvailableAvds();


### PR DESCRIPTION
1. Terminate adb connection only if -keepAdbAlive flag is off, which is the default. This solution gives us better control when to terminate the adb connection and when not to do it. Also it suppresses unnecessary exception messages about the fact that adb has already been initialed.
2. when device is connected in DefaultDeviceManager call listeners' onDeviceConnected method (not onDeviceDisconnected)
3. In DefaultDeviceManager when found already connected devices call onDeviceConnected().
