### PR TITLE
Kill logcat process after test is finished

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
@@ -218,7 +218,7 @@ public abstract class AbstractDevice implements AndroidDevice {
     clearCommand.addArgument("clear", false);
     clearCommand.addArgument(aut.getBasePackage(), false);
     try {
-      ShellCommand.exec(command, 20000);
+      ShellCommand.exec(clearCommand, 20000);
     } catch (ShellCommandException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
When we run test several times, every session start new logcat process.
However logcat process never die because logcat waits log forever.
