### PR TITLE
Removed scroll bars from Android driver's WebView in order to allow automated screenshot comparison

### DIFF
--- a/android-driver/res/layout/activity_web_view.xml
+++ b/android-driver/res/layout/activity_web_view.xml
@@ -2,4 +2,5 @@
     android:id="@+id/webview"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
+    android:scrollbars="none"
 />


### PR DESCRIPTION
I've removed the scroll bars from the WebView in order to allow automated screenshots to be compared using automation. For me the scroll bars were messing up image comparison, because they were on a different position and opacity in every screenshot.

Please let me know if there is anything else I can do in order to implement a similar feature, in case you wish to reject the pull request.

E.g. of images:
![screenshot-basic-rb-md5-cc2119d9571bb71dd021accbf970273d](https://cloud.githubusercontent.com/assets/6329322/2536906/5e815cd6-b5a7-11e3-9a85-7cb81864136f.png) - ![screenshot-basic-rb-md5-42b87bfaa7007ec1d78595a697f042e9](https://cloud.githubusercontent.com/assets/6329322/2536911/7528ff84-b5a7-11e3-9c4d-fc14656e442e.png)

_PS: I use Selendroid/Selenium to test the positioning of +/- 3 kinds of layers in around 70000 scenarios per browser._
