### PR TITLE
repaired encoding header for BaseServlet

### DIFF
--- a/selendroid-server-common/src/main/java/io/selendroid/server/BaseServlet.java
+++ b/selendroid-server-common/src/main/java/io/selendroid/server/BaseServlet.java
@@ -66,7 +66,7 @@ public abstract class BaseServlet implements HttpHandler {
     } else if ("DELETE".equals(request.method())) {
       handler = findMatcher(request, deleteHandler);
     }
-    webbitResponse.header("Content-Encoding", "none");
+    webbitResponse.header("Content-Encoding", "identity");
     handleRequest(request, response, handler);
   }
 


### PR DESCRIPTION
Selendroid is not compatible with the Apache HTTP client dependency from Selenium 2.42.0

In case you create HTTP client to communicate with Selendroid server, Selendroid server uses encoding "none" which is not recognized by Selenium. This is server side fault since you are setting encoding to such value Selenium / HTTP client is not able to recognize.

https://stackoverflow.com/questions/20429722/why-doesnt-apache-java-http-library-handle-sites-with-content-encoding-none
https://stackoverflow.com/questions/21339637/java-unsupported-content-coding-text-xml-posting-text-xml
