### PR TITLE
Support for 'activity-alias' manifest tag by adding a new optional capability -launchActivity

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/SelendroidCapabilities.java
@@ -45,6 +45,8 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public static final String PLATFORM_VERSION = "platformVersion";
   public static final String PLATFORM_NAME = "platformName";
   public static final String AUTOMATION_NAME = "automationName";
+  
+  public static final String LAUNCH_ACTIVITY = "launchActivity";
 
   public SelendroidCapabilities(Map<String, ?> from) {
     for (String key : from.keySet()) {
@@ -65,6 +67,10 @@ public class SelendroidCapabilities extends DesiredCapabilities {
 
   public String getAut() {
     return (String) getRawCapabilities().get(AUT);
+  }
+  
+  public String getLaunchActivity() {
+	return (String) getRawCapabilities().get(LAUNCH_ACTIVITY);
   }
 
   public Boolean getEmulator() {
@@ -103,6 +109,10 @@ public class SelendroidCapabilities extends DesiredCapabilities {
 
   public void setAut(String aut) {
     setCapability(AUT, aut);
+  }
+  
+  public void setLaunchActivity(String launchActivity) {
+	setCapability(LAUNCH_ACTIVITY, launchActivity);
   }
 
   public void setEmulator(Boolean emulator) {

--- a/selendroid-standalone/src/main/java/io/selendroid/android/impl/DefaultAndroidApp.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/impl/DefaultAndroidApp.java
@@ -30,7 +30,7 @@ import org.apache.commons.exec.CommandLine;
 public class DefaultAndroidApp implements AndroidApp {
   private File apkFile;
   private String mainPackage = null;
-  private String mainActivity = null;
+  protected String mainActivity = null;
   private String versionName = null;
 
   public DefaultAndroidApp(File apkFile) {

--- a/selendroid-standalone/src/main/java/io/selendroid/android/impl/MultiActivityAndroidApp.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/impl/MultiActivityAndroidApp.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2013 eBay Software Foundation and selendroid committers.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.android.impl;
+
+import java.io.File;
+
+/**
+ * Class offers the option to set the main activity.
+ * <ul>
+ * Useful in following cases:
+ * <li>if the activity to be started is not the one defined in Manifest.xml as
+ * MAIN</li>
+ * <li>or if the {@code<activity-alias>} tag is used instead of {@code<alias>}.</li>
+ * </ul>
+ */
+public class MultiActivityAndroidApp extends DefaultAndroidApp {
+
+	/**
+	 * This constructor is mainly used by the ClassCast to transform
+	 * DefaultAndroidApp into MultiActivityAndroidApp.
+	 * 
+	 * @param app
+	 */
+	public MultiActivityAndroidApp(DefaultAndroidApp app) {
+		super(new File(app.getAbsolutePath()));
+	}
+
+	public void setMainActivity(String mainActivity) {
+		this.mainActivity = mainActivity;
+	}
+
+}


### PR DESCRIPTION
Initial implementation for feature https://github.com/selendroid/selendroid/issues/434

currently supports capability parameter only.

TODO: find a way to identify the MAIN activity even within 'acitivity-alias' tag
