### PR TITLE
Update on sending a.u.t. to background functionality

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/ServerInstrumentation.java
+++ b/selendroid-server/src/main/java/io/selendroid/ServerInstrumentation.java
@@ -414,11 +414,11 @@ public class ServerInstrumentation extends Instrumentation implements ServerDeta
   }
 
   public void backgroundActivity() {
-	activitiesReporter.setBackgroundActivity(activitiesReporter.getCurrentActivity());
-	Intent homeIntent= new Intent(Intent.ACTION_MAIN);
-	homeIntent.addCategory(Intent.CATEGORY_HOME);
-	homeIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-	getTargetContext().startActivity(homeIntent);
+    activitiesReporter.setBackgroundActivity(activitiesReporter.getCurrentActivity());
+    Intent homeIntent= new Intent(Intent.ACTION_MAIN);
+    homeIntent.addCategory(Intent.CATEGORY_HOME);
+    homeIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    getTargetContext().startActivity(homeIntent);
 }
 
   public void resumeActivity() {

--- a/selendroid-test-app/src/test/java/io/selendroid/nativetests/BackgroundAppTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/nativetests/BackgroundAppTest.java
@@ -29,14 +29,18 @@ public class BackgroundAppTest extends BaseAndroidTest {
   public void testBackgroundAppFunctionality() throws Exception {
     openStartActivity();
     driver().backgroundApp();
-    String currentActivity = execCmd(System.getenv("ANDROID_HOME")+"/platform-tools/"+"adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'");
+    String currentActivity = adbCurrentActivity();
     Assert.assertTrue(currentActivity.contains("com.android.launcher2.Launcher"));
     driver().resumeApp();
-    currentActivity = execCmd(System.getenv("ANDROID_HOME")+"/platform-tools/"+"adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'");
+    currentActivity = adbCurrentActivity();
     Assert.assertTrue(currentActivity.contains("io.selendroid.testapp.HomeScreenActivity"));
-}
+  }
 
-public String execCmd(String cmd) throws java.io.IOException {
+  private String adbCurrentActivity() throws Exception {
+    return execCmd(System.getenv("ANDROID_HOME")+"/platform-tools/"+"adb shell dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'");
+  }
+
+  public String execCmd(String cmd) throws java.io.IOException {
     Process proc = Runtime.getRuntime().exec(cmd);
     java.io.InputStream is = proc.getInputStream();
     java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
@@ -48,7 +52,7 @@ public String execCmd(String cmd) throws java.io.IOException {
         val = "";
     }
     return val;
-}
+  }
 
 
 }


### PR DESCRIPTION
Changed the way the application is sent to background. Now the home screen is opened, instead of the activities task being directly moved back. This is what would happen if the user were to hit the "Home" key on his/her device.

Also added a proper BackgroundAppTest in the selendroid test app.
