### PR TITLE
Avoid returning duplicate elements for findElementsBy*.

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
@@ -466,7 +466,14 @@ public class DefaultSelendroidDriver implements SelendroidDriver {
       views.addAll(viewAnalyzer.getTopLevelViews());
       if (instrumentation.getCurrentActivity() != null
           && instrumentation.getCurrentActivity().getCurrentFocus() != null) {
-        views.add(instrumentation.getCurrentActivity().getCurrentFocus());
+        // Make sure the focused view is not a child of an already added top level view
+        View focusedView = instrumentation.getCurrentActivity().getCurrentFocus();
+        View focusedRoot = focusedView.getRootView();
+        boolean topLevel = true;
+        for (View view : views){
+          topLevel = topLevel && !focusedRoot.equals(view);
+        }
+        if (topLevel) views.add(focusedView);
       }
       // sort them to have most recently drawn view show up first
       Collections.sort(views, new Comparator<View>() {

--- a/selendroid-test-app/pom.xml
+++ b/selendroid-test-app/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.2.1</version>
+			<version>4.3.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/selendroid-test-app/res/layout/homescreen.xml
+++ b/selendroid-test-app/res/layout/homescreen.xml
@@ -155,5 +155,25 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:text="パソコン版にする" />
+    
+    <Button
+            android:id="@+id/topLevelElementTest"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="displayAndFocus"
+            android:text="Display and focus on layout" />
 
+    <LinearLayout
+            android:id="@+id/focusedLayout"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:focusable="true"
+            android:focusableInTouchMode="true">
+        <TextView
+                android:id="@+id/focusedText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Should only be found once"/>
+    </LinearLayout>
 </LinearLayout>

--- a/selendroid-test-app/src/main/java/io/selendroid/testapp/HomeScreenActivity.java
+++ b/selendroid-test-app/src/main/java/io/selendroid/testapp/HomeScreenActivity.java
@@ -41,6 +41,7 @@ import android.widget.EditText;
 import android.widget.PopupWindow;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.widget.LinearLayout;
 
 /**
  * Demo project to verify selendroid actions.
@@ -143,6 +144,16 @@ public class HomeScreenActivity extends Activity {
     }
   }
 
+  public void displayAndFocus(View view) {
+    LinearLayout linearLayout = ((LinearLayout) findViewById(io.selendroid.testapp.R.id.focusedLayout));
+    if (linearLayout.isShown()) {
+      linearLayout.setVisibility(View.GONE);
+    } else {
+      linearLayout.setVisibility(View.VISIBLE);
+      linearLayout.requestFocus();
+    }
+  }
+  
   @Override
   protected Dialog onCreateDialog(int id) {
     switch (id) {

--- a/selendroid-test-app/src/test/java/io/selendroid/nativetests/NativeElementFindingTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/nativetests/NativeElementFindingTest.java
@@ -191,7 +191,7 @@ public class NativeElementFindingTest extends BaseAndroidTest {
     openStartActivity();
     String buttonText = "Show Progress Bar for a while";
     List<WebElement> elements = driver().findElements(By.className("android.widget.Button"));
-    Assert.assertEquals(7, elements.size());
+    Assert.assertEquals(8, elements.size());
     Assert.assertEquals(elements.get(1).getText(), buttonText);
   }
 
@@ -229,7 +229,7 @@ public class NativeElementFindingTest extends BaseAndroidTest {
     openStartActivity();
     String buttonText = "EN Button";
     List<WebElement> elements = driver().findElements(By.tagName("Button"));
-    Assert.assertEquals(6, elements.size());
+    Assert.assertEquals(7, elements.size());
     Assert.assertEquals(elements.get(0).getText(), buttonText);
   }
 
@@ -337,5 +337,13 @@ public class NativeElementFindingTest extends BaseAndroidTest {
     driver().findElement(By.id("visibleButtonTest")).click();
     Thread.sleep(1000);
     Assert.assertEquals(textview.isDisplayed(), true);
+  }
+  
+  @Test()
+  public void shouldNotFindDuplicateElements() throws Exception {
+    openStartActivity();
+    driver().findElement(By.id("topLevelElementTest")).click();
+    List<WebElement> elements = driver().findElements(By.id("focusedText"));
+    Assert.assertEquals(elements.size(), 1);
   }
 }


### PR DESCRIPTION
The problem was caused by getTopLevelViews() in NativeSearchScope
incorrectly returning the focused view even when it should not be
considered as top level.
