### PR TITLE
Fixes bug in findElementsByName()

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
@@ -317,14 +317,22 @@ public abstract class AbstractNativeElementContext
   }
 
   class ViewContentDescriptionPredicate implements Predicate<View> {
-    private String contenDescription = null;
+    private String contentDescription = null;
 
-    ViewContentDescriptionPredicate(String contenDescription) {
-      this.contenDescription = contenDescription;
+    ViewContentDescriptionPredicate(String contentDescription) {
+      this.contentDescription = contentDescription;
     }
 
     public boolean apply(View view) {
-      return contenDescription.equals(view.getContentDescription());
+      return charSequenceEquals(contentDescription, view.getContentDescription());
+    }
+
+    private boolean charSequenceEquals(String s, CharSequence cs) {
+      if (s == null) {
+        return cs == null;
+      } else {
+        return cs != null && s.contentEquals(cs);
+      }
     }
   }
 


### PR DESCRIPTION
Calling .equals with charSequences is in general undefined, and produces the wrong result.
Updated to use String.contentEquals()

Submitted on behalf of a third-party: Facebook
