### PR TITLE
Allowed disabling of adb logcat device logging with flag

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
@@ -13,19 +13,15 @@
  */
 package io.selendroid;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-
-import com.google.common.reflect.Reflection;
-
+import io.selendroid.log.LogLevelConverter;
+import io.selendroid.log.LogLevelEnum;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import io.selendroid.log.LogLevelConverter;
-import io.selendroid.log.LogLevelEnum;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SelendroidConfiguration {
 
@@ -109,6 +105,11 @@ public class SelendroidConfiguration {
   @Parameter(names = "-logLevel", converter = LogLevelConverter.class,
              description = "Specifies the log level of selendroid. Available values are: ERROR, WARNING, INFO, DEBUG and VERBOSE.")
   private LogLevelEnum logLevel = LogLevelEnum.ERROR;
+
+  @Parameter(names = "-deviceLog",
+             description = "Specifies whether or not adb logging should be enabled for the device running the test",
+             arity = 1)
+  private boolean deviceLog = true;
 
   public void setKeystore(String keystore) {
     this.keystore = keystore;
@@ -266,6 +267,14 @@ public class SelendroidConfiguration {
 
   public void setLogLevel(LogLevelEnum logLevel) {
     this.logLevel = logLevel;
+  }
+
+  public boolean isDeviceLog() {
+    return deviceLog;
+  }
+
+  public void setDeviceLog(boolean deviceLog) {
+    this.deviceLog = deviceLog;
   }
 
   @Override

--- a/selendroid-standalone/src/main/java/io/selendroid/android/AndroidDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/AndroidDevice.java
@@ -51,6 +51,10 @@ public interface AndroidDevice {
 
   public List<LogEntry> getLogs();
 
+  public boolean isLoggingEnabled();
+
+  public void setLoggingEnabled(boolean loggingEnabled);
+
   public boolean screenSizeMatches(String requestedScreenSize);
 
   public Locale getLocale();

--- a/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
@@ -53,7 +53,6 @@ import com.android.ddmlib.RawImage;
 import com.android.ddmlib.TimeoutException;
 import com.beust.jcommander.internal.Lists;
 import com.google.common.collect.ObjectArrays;
-import org.openqa.selenium.remote.Command;
 
 public abstract class AbstractDevice implements AndroidDevice {
   private static final Logger log = Logger.getLogger(AbstractDevice.class.getName());
@@ -64,6 +63,7 @@ public abstract class AbstractDevice implements AndroidDevice {
   private ByteArrayOutputStream logoutput;
   private ExecuteWatchdog logcatWatchdog;
   private static final Integer COMMAND_TIMEOUT = 20000;
+  private boolean loggingEnabled = true;
 
   /**
    * Constructor meant to be used with Android Emulators because a reference to the {@link IDevice}
@@ -237,7 +237,10 @@ public abstract class AbstractDevice implements AndroidDevice {
     }
 
     forwardSelendroidPort(port);
-    startLogging();
+
+    if(isLoggingEnabled()) {
+      startLogging();
+    }
   }
 
   public void forwardPort(int local, int remote) {
@@ -306,6 +309,16 @@ public abstract class AbstractDevice implements AndroidDevice {
       log.fine(lines[x]);
     }
     return logs;
+  }
+
+  @Override
+  public boolean isLoggingEnabled() {
+    return loggingEnabled;
+  }
+
+  @Override
+  public void setLoggingEnabled(boolean loggingEnabled) {
+    this.loggingEnabled = loggingEnabled;
   }
 
   private void startLogging() {

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
@@ -66,10 +66,12 @@ public class RequestRedirectHandler extends BaseSelendroidServerHandler {
       } catch (Exception e) {
         if (retries == 0) {
           AndroidDevice device = session.getDevice();
-          log.info("getting logs");
-          device.setVerbose();
-          for (LogEntry le : device.getLogs()) {
-            System.out.println(le.getMessage());
+          if (device.isLoggingEnabled()) {
+            log.info("getting logs");
+            device.setVerbose();
+            for (LogEntry le : device.getLogs()) {
+              System.out.println(le.getMessage());
+            }
           }
           return new SelendroidResponse(sessionId, 13,
                   new SelendroidException(

--- a/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
@@ -288,6 +288,9 @@ public class SelendroidStandaloneDriver implements ServerDetails {
       device.runAdbCommand(adbCommandParameter);
     }
 
+    // Configure logging on the device
+    device.setLoggingEnabled(serverConfiguration.isDeviceLog());
+
     // It's GO TIME!
     // start the selendroid server on the device and make sure it's up
     try {


### PR DESCRIPTION
Adds the command line flag -deviceLog, which can be set to "-deviceLog false" to avoid cluttering test output.
