### PR TITLE
Cleaned up repetitive error handling in selendroid-server

### DIFF
--- a/selendroid-server-common/src/main/java/io/selendroid/server/StatusCode.java
+++ b/selendroid-server-common/src/main/java/io/selendroid/server/StatusCode.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum StatusCode {
+  SUCCESS(0), /* The command executed successfully. */
+  NO_SUCH_DRIVER(6), /* A session is either terminated or not started */
+  NO_SUCH_ELEMENT(7), /* An element could not be located on the page
+  using the given search parameters. */
+  NO_SUCH_FRAME(8), /* A request to switch to a frame could not be satisfied
+  because the frame could not be found. */
+  UNKNOWN_COMMAND(9), /*  The requested resource could not be found,
+  or a request was received using an HTTP method that is not supported by the mapped resource.  */
+  STALE_ELEMENT_REFERENCE(10), /* An element command failed
+  because the referenced element is no longer attached to the DOM. */
+  ELEMENT_NOT_VISIBLE(11), /* An element command could not be completed
+  because the element is not visible on the page. */
+  INVALID_ELEMENT_STATE(12), /* An element command could not be completed
+   because the element is in an invalid state (e.g. attempting to click a disabled element). */
+  UNKNOWN_ERROR(13), /* An unknown server-side error occurred while processing the command. */
+  ELEMENT_IS_NOT_SELECTABLE(15), /* An attempt was made to select an element
+   that cannot be selected. */
+  JAVA_SCRIPT_ERROR(17), /* An error occurred while executing user supplied JavaScript. */
+  X_PATH_LOOKUP_ERROR(19), /* An error occurred while searching for an element by XPath. */
+  TIMEOUT(21), /* An operation did not complete before its timeout expired. */
+  NO_SUCH_WINDOW(23), /* A request to switch to a different window could not be satisfied
+  because the window could not be found. */
+  INVALID_COOKIE_DOMAIN(24),
+  /* An illegal attempt was made to set a cookie under a different domain than the current page. */
+  UNABLE_TO_SET_COOKIE(25), /* A request to set a cookie's value could not be satisfied. */
+  UNEXPECTED_ALERT_OPEN(26), /*  A modal dialog was open, blocking this operation  */
+  NO_ALERT_OPEN_ERROR(27),
+  /* An attempt was made to operate on a modal dialog when one was not open. */
+  SCRIPT_TIMEOUT(28), /* A script did not complete before its timeout expired. */
+  INVALID_ELEMENT_COORDINATES(29), /* The coordinates provided to an interactions operation
+   are invalid. */
+  IME_NOT_AVAILABLE(30), /* IME was not available. */
+  IME_ENGINE_ACTIVATION_FAILED(31), /* An IME engine could not be started. */
+  INVALID_SELECTOR(32), /* Argument was an invalid selector (e.g. XPath/CSS). */
+  SESSION_NOT_CREATED_EXCEPTION(33), /* A new session could not be created. */
+  MOVE_TARGET_OUT_OF_BOUNDS(34); /* Target provided for a move action is out of bounds. */
+
+  private static Map<Integer, StatusCode> statusCodeMap = new HashMap<Integer, StatusCode>();
+
+  static {
+    // Build map so we get the StatusCode for a given int in the pesky dynamic bits
+    for (StatusCode statusCode : StatusCode.values()) {
+      statusCodeMap.put(statusCode.getCode(), statusCode);
+    }
+  }
+
+  private int code;
+
+  private StatusCode(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  public static StatusCode fromInteger(Integer code) {
+    return statusCodeMap.get(code);
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/AndroidServlet.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/AndroidServlet.java
@@ -293,7 +293,9 @@ public class AndroidServlet extends BaseServlet {
             (DefaultSelendroidDriver) request.data().get(AndroidServlet.DRIVER_KEY);
         if (driver != null && driver.isAlertPresent()) {
           result =
-              new SelendroidResponse(handler.getSessionId(request), 26, "Unhandled Alert present");
+              new SelendroidResponse(handler.getSessionId(request),
+                  StatusCode.UNEXPECTED_ALERT_OPEN,
+                  "Unhandled Alert present");
           handleResponse(request, response, (SelendroidResponse) result);
           return;
         }
@@ -302,7 +304,7 @@ public class AndroidServlet extends BaseServlet {
     } catch (StaleElementReferenceException se) {
       try {
         String sessionId = getParameter(handler.getMappedUri(), request.uri(), ":sessionId");
-        result = new SelendroidResponse(sessionId, 10, se);
+        result = new SelendroidResponse(sessionId, StatusCode.STALE_ELEMENT_REFERENCE, se);
       } catch (Exception e) {
         SelendroidLogger.error("Error occurred while handling request and got StaleRef.", e);
         replyWithServerError(response);
@@ -311,7 +313,7 @@ public class AndroidServlet extends BaseServlet {
     } catch (AppCrashedException ae) {
       try {
         String sessionId = getParameter(handler.getMappedUri(), request.uri(), ":sessionId");
-        result = new SelendroidResponse(sessionId, 13, ae);
+        result = new SelendroidResponse(sessionId, StatusCode.UNKNOWN_ERROR, ae);
       } catch (Exception e) {
         SelendroidLogger.error("Error occurred while handling request and got AppCrashedException.",
             e);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/AddCallLog.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/AddCallLog.java
@@ -14,7 +14,7 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.exceptions.PermissionDeniedException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
@@ -27,14 +27,14 @@ import org.json.JSONObject;
 
 import com.google.gson.Gson;
 
-public class AddCallLog extends RequestHandler {
+public class AddCallLog extends SafeRequestHandler {
 
   public AddCallLog(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("add call log");
     JSONObject parameters = getPayload(request).getJSONObject("parameters");
     String callLogJson = parameters.getString("calllogjson");
@@ -47,7 +47,7 @@ public class AddCallLog extends RequestHandler {
     }
     catch(PermissionDeniedException e) {
         SelendroidLogger.info("WRITE_CALL_LOG permission must be in a.u.t. to write to call log.");
-        return new SelendroidResponse(getSessionId(request), 10, e);
+        throw e;
     }
   }
   

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/AddCookie.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/AddCookie.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.Cookie;
@@ -25,7 +25,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class AddCookie extends RequestHandler {
+public class AddCookie extends SafeRequestHandler {
 
   public AddCookie(String mappedUri) {
     super(mappedUri);
@@ -33,8 +33,7 @@ public class AddCookie extends RequestHandler {
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
-
+  public Response safeHandle(HttpRequest request) throws JSONException {
     Date expiry = null;
     SelendroidLogger.info("set cookie to a session command");
     String url = getSelendroidDriver(request).getCurrentUrl();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/BackgroundApp.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/BackgroundApp.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
@@ -22,14 +22,14 @@ import io.selendroid.util.SelendroidLogger;
 
 import org.json.JSONException;
 
-public class BackgroundApp extends RequestHandler {
+public class BackgroundApp extends SafeRequestHandler {
 
   public BackgroundApp(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Background app command");
     ((DefaultSelendroidDriver)getSelendroidDriver(request)).backgroundApp();
     return new SelendroidResponse(getSessionId(request), "sent app to background");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/CaptureScreenshot.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/CaptureScreenshot.java
@@ -14,7 +14,7 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.android.internal.Base64Encoder;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -22,14 +22,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class CaptureScreenshot extends RequestHandler {
+public class CaptureScreenshot extends SafeRequestHandler {
 
   public CaptureScreenshot(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException{
+  public Response safeHandle(HttpRequest request) throws JSONException{
     SelendroidLogger.info("take screenshot command");
     byte[] rawPng = getSelendroidDriver(request).takeScreenshot();
     String base64Png = new Base64Encoder().encode(rawPng);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/ClearElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/ClearElement.java
@@ -13,9 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.NoSuchElementException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.AndroidElement;
@@ -24,29 +22,18 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class ClearElement extends RequestHandler {
+public class ClearElement extends SafeRequestHandler {
 
   public ClearElement(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request)throws JSONException {
+  public Response safeHandle(HttpRequest request)throws JSONException {
     SelendroidLogger.info("Clear element command");
     String id = getElementId(request);
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new NoSuchElementException("The element with id '"
-          + id + "' was not found."));
-    }
-    try {
-      element.clear();
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    } catch (Exception e) {
-      SelendroidLogger.error("error while clearing the element: ", e);
-      return new SelendroidResponse(getSelendroidDriver(request).getSession().getSessionId(), 13, e);
-    }
+    element.clear();
     return new SelendroidResponse(getSessionId(request), "");
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/ClickElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/ClickElement.java
@@ -13,9 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.ElementNotVisibleException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.AndroidElement;
@@ -24,33 +22,18 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class ClickElement extends RequestHandler {
+public class ClickElement extends SafeRequestHandler {
 
   public ClickElement(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Click element command");
     String id = getElementId(request);
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new StaleElementReferenceException(
-          "The element with id '" + id + "' was not found."));
-    }
-    try {
-      element.click();
-    } catch (ElementNotVisibleException ev) {
-      return new SelendroidResponse(getSessionId(request), 11, ev);
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    } catch (IllegalStateException ise) {
-      return new SelendroidResponse(getSessionId(request), 10, ise);
-    } catch (Exception e) {
-      SelendroidLogger.error("error while clicking the element: ", e);
-      return new SelendroidResponse(getSessionId(request), 13, e);
-    }
+    element.click();
     return new SelendroidResponse(getSessionId(request), "");
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/DeleteCookies.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/DeleteCookies.java
@@ -14,7 +14,7 @@
 package io.selendroid.server.handler;
 
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -22,14 +22,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class DeleteCookies extends RequestHandler {
+public class DeleteCookies extends SafeRequestHandler {
 
   public DeleteCookies(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("delete session cookies command");
     String url = getSelendroidDriver(request).getCurrentUrl();
     getSelendroidDriver(request).deleteCookie(url);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/DeleteNamedCookie.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/DeleteNamedCookie.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -21,14 +21,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class DeleteNamedCookie extends RequestHandler {
+public class DeleteNamedCookie extends SafeRequestHandler {
 
   public DeleteNamedCookie(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("delete session cookie by name command");
     String url = getSelendroidDriver(request).getCurrentUrl();
     String name = url.substring(url.lastIndexOf("/") + 1);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/DeleteSession.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/DeleteSession.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.SelendroidDriver;
@@ -22,14 +22,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class DeleteSession extends RequestHandler {
+public class DeleteSession extends SafeRequestHandler {
 
   public DeleteSession(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException{
+  public Response safeHandle(HttpRequest request) throws JSONException{
     SelendroidLogger.info("delete session command");
     SelendroidDriver driver = getSelendroidDriver(request);
 

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/DoubleTapOnElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/DoubleTapOnElement.java
@@ -13,8 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.AndroidElement;
@@ -26,23 +25,19 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class DoubleTapOnElement extends RequestHandler {
+public class DoubleTapOnElement extends SafeRequestHandler {
 
   public DoubleTapOnElement(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("double tap on element gesture");
     JSONObject payload = getPayload(request);
     String elementId = payload.getString("element");
     TouchScreen touchScreen = getSelendroidDriver(request).getTouch();
     AndroidElement element = getElementFromCache(request, elementId);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-          + elementId + "' was not found."));
-    }
     Coordinates elementLocation = element.getCoordinates();
 
     touchScreen.doubleTap(elementLocation);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/Down.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/Down.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.TouchScreen;
@@ -23,14 +23,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class Down extends RequestHandler {
+public class Down extends SafeRequestHandler {
 
   public Down(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Down gesture");
     JSONObject payload=getPayload(request);
     int x = payload.getInt("x");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/ElementLocation.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/ElementLocation.java
@@ -14,41 +14,30 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.android.internal.Point;
-import io.selendroid.exceptions.NoSuchElementException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.http.HttpRequest;
 
-public class ElementLocation extends RequestHandler {
+public class ElementLocation extends SafeRequestHandler {
 
   public ElementLocation(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Get element location command");
     String id = getElementId(request);
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new NoSuchElementException("The element with id '"
-          + id + "' was not found."));
-    }
     Point point = element.getLocation();
     JSONObject result = new JSONObject();
     result.put("x", point.x);
     result.put("y", point.y);
-    try {
-      return new SelendroidResponse(getSessionId(request), result);
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    }
+    return new SelendroidResponse(getSessionId(request), result);
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/FindElements.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/FindElements.java
@@ -13,31 +13,28 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.NoSuchElementException;
-import io.selendroid.exceptions.UnsupportedOperationException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.server.model.By;
 import io.selendroid.server.model.internal.NativeAndroidBySelector;
 import io.selendroid.util.SelendroidLogger;
-
-import java.util.List;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.http.HttpRequest;
 
-public class FindElements extends RequestHandler {
+import java.util.List;
+
+public class FindElements extends SafeRequestHandler {
 
   public FindElements(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     JSONObject payload = getPayload(request);
     String method = payload.getString("using");
     String selector = payload.getString("value");
@@ -45,14 +42,8 @@ public class FindElements extends RequestHandler {
         selector));
 
     By by = new NativeAndroidBySelector().pickFrom(method, selector);
-    List<AndroidElement> elements = null;
-    try {
-      elements = getSelendroidDriver(request).findElements(by);
-    } catch (NoSuchElementException e) {
-      return new SelendroidResponse(getSessionId(request), new JSONArray());
-    } catch (UnsupportedOperationException e) {
-      return new SelendroidResponse(getSessionId(request), 32, e);
-    }
+    List<AndroidElement> elements = getSelendroidDriver(request).findElements(by);
+
     JSONArray result = new JSONArray();
     for (AndroidElement element : elements) {
       JSONObject jsonElement = new JSONObject();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/Flick.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/Flick.java
@@ -13,27 +13,25 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.server.model.TouchScreen;
 import io.selendroid.server.model.interactions.Coordinates;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.http.HttpRequest;
 
-public class Flick extends RequestHandler {
+public class Flick extends SafeRequestHandler {
 
   public Flick(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("flick gesture");
 
     JSONObject payload = getPayload(request);
@@ -44,10 +42,6 @@ public class Flick extends RequestHandler {
       int yOffset = payload.getInt("yoffset");
       int speed = payload.getInt("speed");
       AndroidElement element = getElementFromCache(request, elementId);
-      if (element == null) {
-        return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-            + elementId + "' was not found."));
-      }
       Coordinates elementLocation = element.getCoordinates();
       touchScreen.flick(elementLocation, xOffset, yOffset, speed);
     } else {

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/FrameSwitchHandler.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/FrameSwitchHandler.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 
@@ -21,14 +21,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class FrameSwitchHandler extends RequestHandler {
+public class FrameSwitchHandler extends SafeRequestHandler {
 
   public FrameSwitchHandler(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     JSONObject payload = getPayload(request);
     getSelendroidDriver(request).setFrameContext(payload.get("id"));
     return new SelendroidResponse(getSessionId(request), null);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetCapabilities.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetCapabilities.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.Session;
@@ -23,14 +23,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetCapabilities extends RequestHandler {
+public class GetCapabilities extends SafeRequestHandler {
 
   public GetCapabilities(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get capabilities command");
     Session session = getSelendroidDriver(request).getSession();
 

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetCommandConfiguration.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetCommandConfiguration.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.Session;
@@ -25,14 +25,14 @@ import io.selendroid.server.http.HttpRequest;
 /**
  * Determine the configuration of a command.
  */
-public class GetCommandConfiguration extends RequestHandler {
+public class GetCommandConfiguration extends SafeRequestHandler {
 
   public GetCommandConfiguration(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Get command configuration");
     Session session = getSelendroidDriver(request).getSession();
     String command = getCommandName(request);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetContext.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetContext.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -21,14 +21,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetContext extends RequestHandler {
+public class GetContext extends SafeRequestHandler {
 
   public GetContext(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get context/windowHandle command");
 
     String windowHandle = getSelendroidDriver(request).getContext();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetContexts.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetContexts.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -24,14 +24,14 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetContexts extends RequestHandler {
+public class GetContexts extends SafeRequestHandler {
 
   public GetContexts(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get contexts/windowHandles command");
 
     Set<String> windowHandles = getSelendroidDriver(request).getContexts();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetCookies.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetCookies.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.Cookie;
@@ -26,14 +26,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetCookies extends RequestHandler {
+public class GetCookies extends SafeRequestHandler {
 
   public GetCookies(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
 
     SelendroidLogger.info("get cookies of a session command");
     String url = getSelendroidDriver(request).getCurrentUrl();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetCurrentUrl.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetCurrentUrl.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -21,14 +21,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetCurrentUrl extends RequestHandler {
+public class GetCurrentUrl extends SafeRequestHandler {
 
   public GetCurrentUrl(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException{
+  public Response safeHandle(HttpRequest request) throws JSONException{
     SelendroidLogger.info("get current URL command");
     
     return new SelendroidResponse(getSessionId(request), getSelendroidDriver(request).getCurrentUrl());

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementAttribute.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementAttribute.java
@@ -14,38 +14,29 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.exceptions.NoSuchElementAttributeException;
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
-import io.selendroid.server.http.HttpRequest;
 
-public class GetElementAttribute extends RequestHandler {
+public class GetElementAttribute extends SafeRequestHandler {
 
   public GetElementAttribute(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get attribute of element command");
     String id = getElementId(request);
     String attributeName = getNameAttribute(request);
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '" + id
-          + "' was not found."));
-    }
     String text = null;
     try {
       text = element.getAttribute(attributeName);
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
     } catch (NoSuchElementAttributeException e) {
       // attribute not found
     }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementDisplayed.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementDisplayed.java
@@ -13,36 +13,26 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
-import io.selendroid.server.http.HttpRequest;
 
-public class GetElementDisplayed extends RequestHandler {
+public class GetElementDisplayed extends SafeRequestHandler {
 
   public GetElementDisplayed(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("is element displayed command");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new StaleElementReferenceException("Element with id '" + id
-          + "' was not found."));
-    }
-    try {
-      return new SelendroidResponse(getSessionId(request), element.isDisplayed());
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    }
+    return new SelendroidResponse(getSessionId(request), element.isDisplayed());
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementEnabled.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementEnabled.java
@@ -13,37 +13,26 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
-import io.selendroid.server.http.HttpRequest;
 
-public class GetElementEnabled extends RequestHandler {
+public class GetElementEnabled extends SafeRequestHandler {
 
   public GetElementEnabled(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("is element enabled command");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '" + id
-          + "' was not found in cache."));
-    }
-    try {
-      return new SelendroidResponse(getSessionId(request), element.isEnabled());
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    }
+    return new SelendroidResponse(getSessionId(request), element.isEnabled());
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementLocationInView.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementLocationInView.java
@@ -14,43 +14,32 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.android.internal.Point;
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.http.HttpRequest;
 
-public class GetElementLocationInView extends RequestHandler {
+public class GetElementLocationInView extends SafeRequestHandler {
 
   public GetElementLocationInView(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get element location in view");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException(
-          "Element with id '" + id + "' was not found."));
-    }
     Point location = element.getLocation();
     JSONObject result = new JSONObject();
     result.put("x", location.x);
     result.put("y", location.y);
 
-    try {
-      return new SelendroidResponse(getSessionId(request), result);
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    }
+    return new SelendroidResponse(getSessionId(request), result);
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementSelected.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementSelected.java
@@ -13,9 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.AndroidElement;
@@ -24,27 +22,19 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetElementSelected extends RequestHandler {
+public class GetElementSelected extends SafeRequestHandler {
 
   public GetElementSelected(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("is element selected command");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '" + id
-          + "' was not found."));
-    }
     boolean selected=element.isSelected();
-    try {
-      return new SelendroidResponse(getSessionId(request), selected);
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    }
+    return new SelendroidResponse(getSessionId(request), selected);
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementSize.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementSize.java
@@ -14,43 +14,32 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.android.internal.Dimension;
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.http.HttpRequest;
 
-public class GetElementSize extends RequestHandler {
+public class GetElementSize extends SafeRequestHandler {
 
   public GetElementSize(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get element size command");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '" + id
-          + "' was not found."));
-    }
     Dimension dimension = element.getSize();
-    JSONObject result=new JSONObject();
+    JSONObject result = new JSONObject();
     result.put("width", dimension.width);
     result.put("height", dimension.height);
-    try {
-      return new SelendroidResponse(getSessionId(request), result);
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    }
+    return new SelendroidResponse(getSessionId(request), result);
   }
 
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementTagName.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetElementTagName.java
@@ -13,32 +13,25 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
-import io.selendroid.server.http.HttpRequest;
 
-public class GetElementTagName extends RequestHandler {
+public class GetElementTagName extends SafeRequestHandler {
 
   public GetElementTagName(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get tag name of element command");
     String id = getElementId(request);
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-          + id + "' was not found."));
-    }
-
     return new SelendroidResponse(getSessionId(request), element.getTagName());
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetPageTitle.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetPageTitle.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.SelendroidDriver;
@@ -21,20 +21,15 @@ import io.selendroid.server.model.SelendroidDriver;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetPageTitle extends RequestHandler {
+public class GetPageTitle extends SafeRequestHandler {
 
   public GetPageTitle(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidDriver driver = getSelendroidDriver(request);
-
-    try {
-      return new SelendroidResponse(getSessionId(request), driver.getTitle());
-    } catch (UnsupportedOperationException e) {
-      return new SelendroidResponse(getSessionId(request), 9, e);
-    }
+    return new SelendroidResponse(getSessionId(request), driver.getTitle());
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetScreenOrientation.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetScreenOrientation.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -21,14 +21,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetScreenOrientation extends RequestHandler {
+public class GetScreenOrientation extends SafeRequestHandler {
 
   public GetScreenOrientation(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Go screen orientation");
 
     return new SelendroidResponse(getSessionId(request), getSelendroidDriver(request)

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetScreenState.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetScreenState.java
@@ -1,6 +1,6 @@
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.TouchScreen;
@@ -11,14 +11,14 @@ import io.selendroid.server.http.HttpRequest;
 /**
  * Determine whether the screen of the device is on or off.
  */
-public class GetScreenState extends RequestHandler {
+public class GetScreenState extends SafeRequestHandler {
 
   public GetScreenState(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Get screen state");
 
     TouchScreen screen = getSelendroidDriver(request).getTouch();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetText.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetText.java
@@ -13,39 +13,28 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
-
-import org.json.JSONException;
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.StaleElementReferenceException;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
-import io.selendroid.server.http.HttpRequest;
+import org.json.JSONException;
 
-public class GetText extends RequestHandler {
+public class GetText extends SafeRequestHandler {
 
   public GetText(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get text command");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-          + id + "' was not found."));
-    }
     String text = element.getText();
-    try {
-      return new SelendroidResponse(getSessionId(request), text);
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    }
+    return new SelendroidResponse(getSessionId(request), text);
   }
 
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GetWindowSize.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GetWindowSize.java
@@ -14,7 +14,7 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.android.internal.Dimension;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -22,14 +22,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetWindowSize  extends RequestHandler {
+public class GetWindowSize  extends SafeRequestHandler {
 
     public GetWindowSize(String mappedUri) {
         super(mappedUri);
     }
 
     @Override
-    public Response handle(HttpRequest request) throws JSONException {
+    public Response safeHandle(HttpRequest request) throws JSONException {
         SelendroidLogger.info("get window size command");
 
         Dimension size = getSelendroidDriver(request).getWindowSize();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GoBack.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GoBack.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
@@ -21,14 +21,14 @@ import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GoBack extends RequestHandler {
+public class GoBack extends SafeRequestHandler {
 
   public GoBack(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Go Back");
 
     getSelendroidDriver(request).back();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/GoForward.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/GoForward.java
@@ -13,30 +13,24 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.UnsupportedOperationException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
-import io.selendroid.util.SelendroidLogger;
-
-import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
+import io.selendroid.util.SelendroidLogger;
+import org.json.JSONException;
 
-public class GoForward extends RequestHandler {
+public class GoForward extends SafeRequestHandler {
 
   public GoForward(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Go Forward");
-    try {
-      getSelendroidDriver(request).forward();
-      return new SelendroidResponse(getSessionId(request), "");
-    } catch (UnsupportedOperationException e) {
-      return new SelendroidResponse(getSessionId(request), 9, e);
-    }
+    getSelendroidDriver(request).forward();
+    return new SelendroidResponse(getSessionId(request), "");
   }
 
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/InspectorTap.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/InspectorTap.java
@@ -14,7 +14,7 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.android.internal.Point;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.SelendroidDriver;
@@ -25,14 +25,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
 
-public class InspectorTap extends RequestHandler {
+public class InspectorTap extends SafeRequestHandler {
 
   public InspectorTap(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Inspector click on position command");
 
     JSONObject payload = getPayload(request);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/ListSessions.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/ListSessions.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 
 import org.json.JSONArray;
@@ -22,14 +22,14 @@ import org.json.JSONObject;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
 
-public class ListSessions extends RequestHandler {
+public class ListSessions extends SafeRequestHandler {
 
   public ListSessions(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     JSONArray sessions = new JSONArray();
     if (getSelendroidDriver(request).getSession() != null) {
       JSONObject sessionResponse = new JSONObject();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/LogElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/LogElement.java
@@ -13,8 +13,9 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
+import io.selendroid.server.StatusCode;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.server.model.AndroidNativeElement;
 import io.selendroid.server.model.AndroidWebElement;
@@ -24,25 +25,22 @@ import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
 
-public class LogElement extends RequestHandler {
+public class LogElement extends SafeRequestHandler {
 
   public LogElement(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("get source of element command");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '" + id
-          + "' was not found."));
-    }
     if (element instanceof AndroidWebElement) {
-      return new SelendroidResponse(getSessionId(request), 12, new SelendroidException(
-          "Get source of element is only supported for native elements."));
+      return new SelendroidResponse(getSessionId(request),
+          StatusCode.INVALID_ELEMENT_STATE,
+          new SelendroidException("Get source of element is only supported for native elements."));
     }
 
     return new SelendroidResponse(getSessionId(request), ((AndroidNativeElement) element).toJson().toString());

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/LogElementTree.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/LogElementTree.java
@@ -13,21 +13,21 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
 
 import io.selendroid.server.http.HttpRequest;
 
-public class LogElementTree extends RequestHandler {
+public class LogElementTree extends SafeRequestHandler {
 
   public LogElementTree(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) {
+  public Response safeHandle(HttpRequest request) {
     SelendroidLogger.info("LogElementTree for session: "
         + getSelendroidDriver(request).getSession().getSessionId());
     String source = getSelendroidDriver(request).getWindowSource();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/LongPressOnElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/LongPressOnElement.java
@@ -13,36 +13,29 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.server.model.interactions.Coordinates;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.http.HttpRequest;
 
-public class LongPressOnElement extends RequestHandler {
+public class LongPressOnElement extends SafeRequestHandler {
 
   public LongPressOnElement(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Long press on element gesture");
     JSONObject payload = getPayload(request);
     String elementId = payload.getString("element");
 
     AndroidElement element = getElementFromCache(request, elementId);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-          + elementId + "' was not found."));
-    }
-
     Coordinates elementLocation = element.getCoordinates();
     getSelendroidDriver(request).getTouch().longPress(elementLocation);
     return new SelendroidResponse(getSessionId(request), "");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/Move.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/Move.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 
 import org.json.JSONException;
@@ -22,14 +22,14 @@ import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
 import io.selendroid.server.http.HttpRequest;
 
-public class Move extends RequestHandler {
+public class Move extends SafeRequestHandler {
 
   public Move(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("move gesture");
     JSONObject payload = getPayload(request);
     int x = payload.getInt("x");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/NewSession.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/NewSession.java
@@ -14,9 +14,10 @@
 package io.selendroid.server.handler;
 
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.exceptions.SelendroidException;
@@ -24,14 +25,14 @@ import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
 import io.selendroid.server.http.HttpRequest;
 
-public class NewSession extends RequestHandler {
+public class NewSession extends SafeRequestHandler {
 
   public NewSession(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("new session command");
     JSONObject payload = getPayload(request);
 
@@ -42,8 +43,8 @@ public class NewSession extends RequestHandler {
       sessionID = getSelendroidDriver(request).initializeSession(desiredCapabilities);
     } catch (SelendroidException e) {
       SelendroidLogger.error("Error while creating new session: ", e);
-      return new SelendroidResponse("", 33, e);
+      return new SelendroidResponse("", StatusCode.SESSION_NOT_CREATED_EXCEPTION, e);
     }
-    return new SelendroidResponse(sessionID, 0, desiredCapabilities);
+    return new SelendroidResponse(sessionID, desiredCapabilities);
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/OpenUrl.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/OpenUrl.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 
 import org.json.JSONException;
@@ -22,20 +22,20 @@ import io.selendroid.server.SelendroidResponse;
 import io.selendroid.util.SelendroidLogger;
 import io.selendroid.server.http.HttpRequest;
 
-public class OpenUrl extends RequestHandler {
+public class OpenUrl extends SafeRequestHandler {
 
   public OpenUrl(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Open URL command");
     String url = getPayload(request).getString("url");
     if (url == null || url.isEmpty()) {
-      return new SelendroidResponse(getSessionId(request), 13, new SelendroidException(
-          "Not able to open Url because Url is missing."));
+      throw new SelendroidException("Not able to open Url because Url is missing.");
     }
+
     getSelendroidDriver(request).get(url);
     return new SelendroidResponse(getSessionId(request), "");
   }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/ReadCallLog.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/ReadCallLog.java
@@ -14,7 +14,8 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.exceptions.PermissionDeniedException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.exceptions.SelendroidException;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
@@ -29,14 +30,14 @@ import org.json.JSONException;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-public class ReadCallLog extends RequestHandler {
+public class ReadCallLog extends SafeRequestHandler {
 
   public ReadCallLog(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("reading call log");
     try {
         List<CallLogEntry> response = ((DefaultSelendroidDriver)getSelendroidDriver(request)).readCallLog();
@@ -45,8 +46,7 @@ public class ReadCallLog extends RequestHandler {
                     new Gson().toJson(response, new TypeToken<List<CallLogEntry>>() {}.getType()));
     }
     catch(PermissionDeniedException e) {
-        SelendroidLogger.info("READ_CALL_LOG permission must be in a.u.t. to read call logs.");
-        return new SelendroidResponse(getSessionId(request), 10, e);
+        throw new SelendroidException("READ_CALL_LOG permission must be in a.u.t. to read call logs.");
     }
   }
   

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/Refresh.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/Refresh.java
@@ -13,31 +13,24 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.UnsupportedOperationException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
-import io.selendroid.util.SelendroidLogger;
-
-import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
+import io.selendroid.util.SelendroidLogger;
+import org.json.JSONException;
 
-public class Refresh extends RequestHandler {
+public class Refresh extends SafeRequestHandler {
 
   public Refresh(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Do Refresh");
-
-    try {
-      getSelendroidDriver(request).refresh();
-      return new SelendroidResponse(getSessionId(request), "");
-    } catch (UnsupportedOperationException e) {
-      return new SelendroidResponse(getSessionId(request), 9, e);
-    }
+    getSelendroidDriver(request).refresh();
+    return new SelendroidResponse(getSessionId(request), "");
   }
 
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/ResumeApp.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/ResumeApp.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
@@ -22,14 +22,14 @@ import io.selendroid.util.SelendroidLogger;
 
 import org.json.JSONException;
 
-public class ResumeApp extends RequestHandler {
+public class ResumeApp extends SafeRequestHandler {
 
   public ResumeApp(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Resume app command");
     ((DefaultSelendroidDriver)getSelendroidDriver(request)).resumeApp();
     return new SelendroidResponse(getSessionId(request), "brought app to foreground");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/RotateScreen.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/RotateScreen.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.ScreenOrientation;
@@ -23,14 +23,14 @@ import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
 
-public class RotateScreen extends RequestHandler {
+public class RotateScreen extends SafeRequestHandler {
 
   public RotateScreen(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Rotate screen");
     String orientation = getPayload(request).getString("orientation");
 

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/Scroll.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/Scroll.java
@@ -13,24 +13,23 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.server.http.HttpRequest;
 
-public class Scroll extends RequestHandler {
+public class Scroll extends SafeRequestHandler {
 
   public Scroll(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     String elementId = getElementId(request);
     JSONObject payload = getPayload(request);
     int xoffset = payload.getInt("xoffset");
@@ -39,10 +38,6 @@ public class Scroll extends RequestHandler {
       getSelendroidDriver(request).getTouch().scroll(xoffset, yoffset);
     } else {
       AndroidElement element = getElementFromCache(request, elementId);
-      if (element == null) {
-        return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-            + elementId + "' was not found."));
-      }
       getSelendroidDriver(request).getTouch().scroll(element.getCoordinates(), xoffset, yoffset);
     }
     return new SelendroidResponse(getSessionId(request), "");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SendKeyToActiveElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SendKeyToActiveElement.java
@@ -13,31 +13,23 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
-import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
 
-public class SendKeyToActiveElement extends RequestHandler {
+public class SendKeyToActiveElement extends SafeRequestHandler {
 
   public SendKeyToActiveElement(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("send key to active element command");
-
-    String[] keysToSend;
-    try {
-      keysToSend = extractKeysToSendFromPayload(request);
-    } catch (SelendroidException e) {
-      return new SelendroidResponse(getSessionId(request), 13, e);
-    }
-
+    String[] keysToSend = extractKeysToSendFromPayload(request);
     getSelendroidDriver(request).getKeyboard().sendKeys(keysToSend);
 
     return new SelendroidResponse(getSessionId(request), "");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SendKeys.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SendKeys.java
@@ -13,40 +13,29 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.http.HttpRequest;
 import io.selendroid.server.model.AndroidElement;
 import io.selendroid.server.model.Session;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.http.HttpRequest;
 
-public class SendKeys extends RequestHandler {
+public class SendKeys extends SafeRequestHandler {
 
   public SendKeys(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("send keys command");
     String id = getElementId(request);
 
     AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException(
-          "Element with id '" + id + "' was not found."));
-    }
-    String[] keysToSend;
-    try {
-      keysToSend = extractKeysToSendFromPayload(request);
-    } catch (SelendroidException e) {
-      return new SelendroidResponse(getSessionId(request), 13, e);
-    }
+    String[] keysToSend = extractKeysToSendFromPayload(request);
 
     if (isNativeEvents(request)) {
       element.enterText(keysToSend);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SetCommandConfiguration.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SetCommandConfiguration.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.Session;
@@ -26,14 +26,14 @@ import io.selendroid.server.http.HttpRequest;
 /**
  * Allow a command to be configured during runtime.
  */
-public class SetCommandConfiguration extends RequestHandler {
+public class SetCommandConfiguration extends SafeRequestHandler {
 
   public SetCommandConfiguration(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("set command configuration command");
     JSONObject payload = getPayload(request);
     Session session = getSelendroidDriver(request).getSession();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SetScreenState.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SetScreenState.java
@@ -1,6 +1,6 @@
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.TouchScreen;
@@ -11,14 +11,14 @@ import io.selendroid.server.http.HttpRequest;
 /**
  * Allow the device's screen to be turned on or off.
  */
-public class SetScreenState extends RequestHandler {
+public class SetScreenState extends SafeRequestHandler {
 
   public SetScreenState(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     JSONObject payload = getPayload(request);
     int percentage = payload.getInt("brightness");
 

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SingleTapOnElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SingleTapOnElement.java
@@ -13,11 +13,10 @@
  */
 package io.selendroid.server.handler;
 
+import io.selendroid.server.SafeRequestHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.AndroidElement;
@@ -26,23 +25,19 @@ import io.selendroid.server.model.interactions.Coordinates;
 import io.selendroid.util.SelendroidLogger;
 import io.selendroid.server.http.HttpRequest;
 
-public class SingleTapOnElement extends RequestHandler {
+public class SingleTapOnElement extends SafeRequestHandler {
 
   public SingleTapOnElement(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("single tap on element gesture");
     JSONObject payload = getPayload(request);
     String elementId = payload.getString("element");
 
     AndroidElement element = getElementFromCache(request, elementId);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-          + elementId + "' was not found."));
-    }
     TouchScreen touchScreen = getSelendroidDriver(request).getTouch();
     
     Coordinates elementLocation = element.getCoordinates();

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SubmitForm.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SubmitForm.java
@@ -13,40 +13,25 @@
  */
 package io.selendroid.server.handler;
 
+import io.selendroid.server.SafeRequestHandler;
 import org.json.JSONException;
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.exceptions.StaleElementReferenceException;
-import io.selendroid.server.RequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
-import io.selendroid.server.model.AndroidElement;
 import io.selendroid.util.SelendroidLogger;
 import io.selendroid.server.http.HttpRequest;
 
-public class SubmitForm extends RequestHandler {
+public class SubmitForm extends SafeRequestHandler {
 
   public SubmitForm(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Submit element command");
-    String id = getElementId(request);
-    AndroidElement element = getElementFromCache(request, id);
-    if (element == null) {
-      return new SelendroidResponse(getSessionId(request), 10, new SelendroidException("Element with id '"
-          + id + "' was not found."));
-    }
+    getElementFromCache(request, getElementId(request)).submit();
+
     String sessionId = getSessionId(request);
-    try {
-      element.submit();
-    } catch (StaleElementReferenceException se) {
-      return new SelendroidResponse(getSessionId(request), 10, se);
-    } catch (Exception e) {
-      SelendroidLogger.error("error while submitting the element: ", e);
-      return new SelendroidResponse(sessionId, 13, e);
-    }
     return new SelendroidResponse(sessionId, "");
   }
 

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SwitchContext.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SwitchContext.java
@@ -13,39 +13,29 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.exceptions.NoSuchContextException;
 import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
-import io.selendroid.server.model.SelendroidDriver;
 import io.selendroid.util.SelendroidLogger;
-
 import org.json.JSONException;
 
-public class SwitchContext extends RequestHandler {
+public class SwitchContext extends SafeRequestHandler {
 
   public SwitchContext(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("Switch Context/Window command");
     String windowName = getPayload(request).getString("name");
     if (windowName == null || windowName.isEmpty()) {
-      return new SelendroidResponse(getSessionId(request), 13, new SelendroidException(
-          "Window name is missing."));
+      throw new SelendroidException("Window name is missing.");
     }
-    SelendroidDriver driver = getSelendroidDriver(request);
-    try {
-      driver.switchContext(windowName);
-    } catch(NoSuchContextException nsce) {
-      //TODO update error code when w3c spec gets updated
-      return new SelendroidResponse(getSessionId(request), 23, new SelendroidException(
-              "Invalid window handle was used: only 'NATIVE_APP' and 'WEBVIEW' are supported."));
-    }
+
+    getSelendroidDriver(request).switchContext(windowName);
     return new SelendroidResponse(getSessionId(request), "");
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/UnknownCommandHandler.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/UnknownCommandHandler.java
@@ -13,23 +13,24 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
 
-public class UnknownCommandHandler extends RequestHandler {
+public class UnknownCommandHandler extends SafeRequestHandler {
 
   public UnknownCommandHandler(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
-    return new SelendroidResponse(getSessionId(request), 9, new SelendroidException(
+  public Response safeHandle(HttpRequest request) throws JSONException {
+    return new SelendroidResponse(getSessionId(request), StatusCode.UNKNOWN_COMMAND, new SelendroidException(
         "The requested command is currently not yet supported by selendroid."));
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/Up.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/Up.java
@@ -13,7 +13,7 @@
  */
 package io.selendroid.server.handler;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
@@ -24,14 +24,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 
-public class Up extends RequestHandler {
+public class Up extends SafeRequestHandler {
 
   public Up(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("up gesture");
     JSONObject payload = getPayload(request);
     int x = payload.getInt("x");

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/alert/Alert.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/alert/Alert.java
@@ -13,26 +13,27 @@
  */
 package io.selendroid.server.handler.alert;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.StatusCode;
 import io.selendroid.util.SelendroidLogger;
 
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class Alert extends RequestHandler {
+public class Alert extends SafeRequestHandler {
 
   public Alert(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("getting alert text");
     if (!getSelendroidDriver(request).isAlertPresent()) {
       SelendroidLogger.info("alert NOT present");
-      return new SelendroidResponse(getSessionId(request), 27, "no alert open");
+      return new SelendroidResponse(getSessionId(request), StatusCode.NO_ALERT_OPEN_ERROR, "no alert open");
     }
     SelendroidLogger.info("getting the text");
     return new SelendroidResponse(getSessionId(request), getSelendroidDriver(request).getAlertText());

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/alert/AlertAccept.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/alert/AlertAccept.java
@@ -13,22 +13,23 @@
  */
 package io.selendroid.server.handler.alert;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class AlertAccept extends RequestHandler {
+public class AlertAccept extends SafeRequestHandler {
 
   public AlertAccept(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     if (!getSelendroidDriver(request).isAlertPresent()) {
-      return new SelendroidResponse(getSessionId(request), 27, "no alert open");
+      return new SelendroidResponse(getSessionId(request), StatusCode.NO_ALERT_OPEN_ERROR, "no alert open");
     }
     getSelendroidDriver(request).acceptAlert();
     return new SelendroidResponse(getSessionId(request), null);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/alert/AlertDismiss.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/alert/AlertDismiss.java
@@ -13,22 +13,23 @@
  */
 package io.selendroid.server.handler.alert;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class AlertDismiss extends RequestHandler {
+public class AlertDismiss extends SafeRequestHandler {
 
   public AlertDismiss(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     if (!getSelendroidDriver(request).isAlertPresent()) {
-      return new SelendroidResponse(getSessionId(request), 27, "no alert open");
+      return new SelendroidResponse(getSessionId(request), StatusCode.NO_ALERT_OPEN_ERROR, "no alert open");
     }
     getSelendroidDriver(request).dismissAlert();
     return new SelendroidResponse(getSessionId(request), null);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/alert/AlertSendKeys.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/alert/AlertSendKeys.java
@@ -13,30 +13,25 @@
  */
 package io.selendroid.server.handler.alert;
 
-import io.selendroid.exceptions.SelendroidException;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
-import org.json.JSONException;
+import io.selendroid.server.StatusCode;
 import io.selendroid.server.http.HttpRequest;
+import org.json.JSONException;
 
-public class AlertSendKeys extends RequestHandler {
+public class AlertSendKeys extends SafeRequestHandler {
 
   public AlertSendKeys(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     if (!getSelendroidDriver(request).isAlertPresent()) {
-      return new SelendroidResponse(getSessionId(request), 27, "no alert open");
+      return new SelendroidResponse(getSessionId(request), StatusCode.NO_ALERT_OPEN_ERROR, "no alert open");
     }
-    String keysToSend = null;
-    try {
-      keysToSend = getPayload(request).getString("text");
-    } catch (SelendroidException e) {
-      return new SelendroidResponse(getSessionId(request), 13, e);
-    }
+    String keysToSend = keysToSend = getPayload(request).getString("text");
     getSelendroidDriver(request).setAlertText(keysToSend);
     return new SelendroidResponse(getSessionId(request), null);
   }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/network/GetNetworkConnectionType.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/network/GetNetworkConnectionType.java
@@ -1,18 +1,18 @@
 package io.selendroid.server.handler.network;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class GetNetworkConnectionType extends RequestHandler {
+public class GetNetworkConnectionType extends SafeRequestHandler {
   public GetNetworkConnectionType(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     return new SelendroidResponse(getSessionId(request), getSelendroidDriver(request).isAirplaneMode() ? 1 : 6);
   }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/AsyncTimeoutHandler.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/AsyncTimeoutHandler.java
@@ -1,17 +1,17 @@
 package io.selendroid.server.handler.timeouts;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class AsyncTimeoutHandler extends RequestHandler {
+public class AsyncTimeoutHandler extends SafeRequestHandler {
   public AsyncTimeoutHandler(String mappedUri) {
     super(mappedUri);
   }
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     getSelendroidDriver(request).setAsyncTimeout(getPayload(request).getLong("ms"));
     return new SelendroidResponse(getSessionId(request), null);
   }

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/SetImplicitWaitTimeout.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/SetImplicitWaitTimeout.java
@@ -14,23 +14,22 @@
 package io.selendroid.server.handler.timeouts;
 
 import io.selendroid.ServerInstrumentation;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.util.SelendroidLogger;
 import org.json.JSONException;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
 
-public class SetImplicitWaitTimeout extends RequestHandler {
+public class SetImplicitWaitTimeout extends SafeRequestHandler {
 
   public SetImplicitWaitTimeout(String mappedUri) {
     super(mappedUri);
   }
 
   @Override
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     SelendroidLogger.info("set implicit wait timeout called");
-
     Long timeout = getPayload(request).getLong("ms");
     
     ServerInstrumentation.getInstance().setImplicitWait(timeout);

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/TimeoutsHandler.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/TimeoutsHandler.java
@@ -1,17 +1,18 @@
 package io.selendroid.server.handler.timeouts;
 
 import io.selendroid.ServerInstrumentation;
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 
-public class TimeoutsHandler extends RequestHandler {
+public class TimeoutsHandler extends SafeRequestHandler {
   public TimeoutsHandler(String uri) {
     super(uri);
   }
-  public Response handle(HttpRequest request) throws JSONException {
+  public Response safeHandle(HttpRequest request) throws JSONException {
     long timeout = getPayload(request).getLong("ms");
     String type = getPayload(request).getString("type");
     if (type.equals("script")) {
@@ -19,7 +20,9 @@ public class TimeoutsHandler extends RequestHandler {
     } else if (type.equals("implicit")) {
       ServerInstrumentation.getInstance().setImplicitWait(timeout);
     } else {
-      return new SelendroidResponse(getSessionId(request), 1, new Exception("Unsupported timeout type: " + type));
+      return new SelendroidResponse(getSessionId(request),
+          StatusCode.UNKNOWN_COMMAND,
+          new Exception("Unsupported timeout type: " + type));
     }
     return new SelendroidResponse(getSessionId(request), null);
   }

--- a/selendroid-server/src/test/java/io/selendroid/server/handlers/SessionAndIdExtractionTestHandler.java
+++ b/selendroid-server/src/test/java/io/selendroid/server/handlers/SessionAndIdExtractionTestHandler.java
@@ -13,18 +13,18 @@
  */
 package io.selendroid.server.handlers;
 
-import io.selendroid.server.RequestHandler;
+import io.selendroid.server.SafeRequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
 
-public class SessionAndIdExtractionTestHandler extends RequestHandler {
+public class SessionAndIdExtractionTestHandler extends SafeRequestHandler {
 
   public SessionAndIdExtractionTestHandler(String mappedUri) {
     super(mappedUri);
   }
 
-  public Response handle(HttpRequest request) {
+  public Response safeHandle(HttpRequest request) {
     return new SelendroidResponse(null, "sessionId#" + getSessionId(request) + " elementId#" + getElementId(request));
   }
 }

--- a/selendroid-server/src/test/java/io/selendroid/server/handlers/SessionAndPayloadExtractionTestHandler.java
+++ b/selendroid-server/src/test/java/io/selendroid/server/handlers/SessionAndPayloadExtractionTestHandler.java
@@ -13,20 +13,20 @@
  */
 package io.selendroid.server.handlers;
 
+import io.selendroid.server.SafeRequestHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
-import io.selendroid.server.RequestHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.http.HttpRequest;
 
-public class SessionAndPayloadExtractionTestHandler extends RequestHandler {
+public class SessionAndPayloadExtractionTestHandler extends SafeRequestHandler {
 
   public SessionAndPayloadExtractionTestHandler(String mappedUri) {
     super(mappedUri);
   }
 
-  public Response handle(HttpRequest request) throws JSONException{
+  public Response safeHandle(HttpRequest request) throws JSONException{
     JSONObject payload = getPayload(request);
     String method = payload.getString("using");
     String selector = payload.getString("value");

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/CaptureScreenshot.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/CaptureScreenshot.java
@@ -17,6 +17,7 @@ import io.selendroid.exceptions.AndroidDeviceException;
 import io.selendroid.server.BaseSelendroidServerHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import org.openqa.selenium.internal.Base64Encoder;
 import io.selendroid.server.http.HttpRequest;
@@ -32,13 +33,13 @@ public class CaptureScreenshot extends BaseSelendroidServerHandler {
 
   @Override
   public Response handle(HttpRequest request) throws JSONException {
-    log.info("take devcie screenshot command");
+    log.info("take device screenshot command");
     byte[] rawPng;
     try {
       rawPng = getSelendroidDriver(request).takeScreenshot(getSessionId(request));
     } catch (AndroidDeviceException e) {
       e.printStackTrace();
-      return new SelendroidResponse(getSessionId(request), 13, e);
+      return new SelendroidResponse(getSessionId(request), StatusCode.UNKNOWN_ERROR, e);
     }
     String base64Png = new Base64Encoder().encode(rawPng);
 

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/CreateSessionHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/CreateSessionHandler.java
@@ -19,6 +19,7 @@ import io.selendroid.server.SelendroidResponse;
 
 import java.util.logging.Logger;
 
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
@@ -43,8 +44,8 @@ public class CreateSessionHandler extends BaseSelendroidServerHandler {
     } catch (Exception e) {
       log.severe("Error while creating new session: " + e.getMessage());
       e.printStackTrace();
-      return new SelendroidResponse("", 33, e);
+      return new SelendroidResponse("", StatusCode.SESSION_NOT_CREATED_EXCEPTION, e);
     }
-    return new SelendroidResponse(sessionID, 0, desiredCapabilities);
+    return new SelendroidResponse(sessionID, desiredCapabilities);
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/GetCapabilities.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/GetCapabilities.java
@@ -18,6 +18,7 @@ import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.server.BaseSelendroidServerHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.StatusCode;
 import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;
@@ -38,7 +39,7 @@ public class GetCapabilities extends BaseSelendroidServerHandler {
 
     SelendroidCapabilities caps = getSelendroidDriver(request).getSessionCapabilities(sessionId);
     if (caps == null) {
-      return new SelendroidResponse(sessionId, 13, new SelendroidException("Session was not found"));
+      return new SelendroidResponse(sessionId, StatusCode.UNKNOWN_ERROR, new SelendroidException("Session was not found"));
     }
     return new SelendroidResponse(sessionId, new JSONObject(caps.asMap()));
   }

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
@@ -18,6 +18,7 @@ import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.server.BaseSelendroidServerHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
+import io.selendroid.server.StatusCode;
 import io.selendroid.server.model.ActiveSession;
 import io.selendroid.server.util.HttpClientUtil;
 import org.apache.http.HttpResponse;
@@ -43,11 +44,11 @@ public class RequestRedirectHandler extends BaseSelendroidServerHandler {
 
     ActiveSession session = getSelendroidDriver(request).getActiveSession(sessionId);
     if (session == null) {
-      return new SelendroidResponse(sessionId, 13, new SelendroidException(
+      return new SelendroidResponse(sessionId, StatusCode.UNKNOWN_ERROR, new SelendroidException(
           "No session found for given sessionId: " + sessionId));
     }
     if (session.isInvalid()) {
-      return new SelendroidResponse(sessionId, 13, new SelendroidException(
+      return new SelendroidResponse(sessionId, StatusCode.UNKNOWN_ERROR, new SelendroidException(
           "The test session has been marked as invalid. "
               + "This happens if a hardware device was disconnected but a "
               + "test session was still active on the device."));
@@ -71,7 +72,7 @@ public class RequestRedirectHandler extends BaseSelendroidServerHandler {
           for (LogEntry le : device.getLogs()) {
             System.out.println(le.getMessage());
           }
-          return new SelendroidResponse(sessionId, 13,
+          return new SelendroidResponse(sessionId, StatusCode.UNKNOWN_ERROR,
                   new SelendroidException(
                           "Error occured while communicating with selendroid server on the device: ",
                           e));
@@ -94,7 +95,7 @@ public class RequestRedirectHandler extends BaseSelendroidServerHandler {
     log.fine("return value from selendroid android server: " + value);
     log.fine("return status from selendroid android server: " + status);
 
-    return new SelendroidResponse(sessionId, status, value);
+    return new SelendroidResponse(sessionId, StatusCode.fromInteger(status), value);
   }
 
   private JSONObject redirectRequest(HttpRequest request, ActiveSession session, String url, String method)


### PR DESCRIPTION
Sorry for the diff size on this one - no functional changes just code cleanup.

Introduced a StatusCode enum to make the SelendroidResponse constructors clearer, also made the integer constructors private to prevent their usage in future.

Also centralised all of the exception handling (StaleElements/ElementNotFound/UnknownError) into a single method handle() in SafeRequestHandler. All child classes of SafeRequestHandler have to implement safeHandle, which has all of it's exceptions handled and converted into SelendroidResponses by it's parent.

This means that we don't need all of the repetitive error handling in all of the handlers and they can be written more "naturally"

Example

```
    AndroidElement element = getElementFromCache(request, id);
    if (element == null) {
      return new SelendroidResponse(getSessionId(request), 10, new NoSuchElementException("The element with id '"
          + id + "' was not found."));
    }
    try {
      element.clear();
    } catch (StaleElementReferenceException se) {
      return new SelendroidResponse(getSessionId(request), 10, se);
    } catch (Exception e) {
      SelendroidLogger.error("error while clearing the element: ", e);
      return new SelendroidResponse(getSelendroidDriver(request).getSession().getSessionId(), 13, e);
    }
    return new SelendroidResponse(getSessionId(request), "");
```

Can now be written

```
    getElementFromCache(request, id).clear();
    return new SelendroidResponse(getSessionId(request), "");
```

Submitted on behalf of: Facebook
