### PR TITLE
Stop swallowing exception when waiting for instrumentation

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
@@ -13,6 +13,7 @@
  */
 package io.selendroid.android.impl;
 
+import com.google.common.base.Throwables;
 import io.selendroid.android.AndroidApp;
 import io.selendroid.android.AndroidDevice;
 import io.selendroid.android.AndroidSdk;
@@ -230,7 +231,8 @@ public abstract class AbstractDevice implements AndroidDevice {
             ObjectArrays.concat(new String[]{"shell", "am", "instrument", "-w"}, args, String.class));
         detailedResult = executeCommand(getErrorDetailCommand);
       } catch (Exception e) {
-        detailedResult = "";
+        detailedResult = "Could not run get detailed result: " +
+            e.getMessage() + "\n" + Throwables.getStackTraceAsString(e);
       }
       throw new SelendroidException("Error occurred while starting selendroid-server on the device",
           new Throwable(result + "\nDetails:\n" + detailedResult));


### PR DESCRIPTION
Previously if we were waiting for more detailed output and that failed we'd swallow the exception. It might actually contain some useful information, so it's better to pass it on.
