### PR TITLE
Allow selendroid-server start timeout to be passed on command line

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
@@ -111,6 +111,10 @@ public class SelendroidConfiguration {
              arity = 1)
   private boolean deviceLog = true;
 
+  @Parameter(description = "Maximum time in milliseconds to wait for the selendroid-server to come up on the device",
+      names = "-serverStartTimeout")
+  private long serverStartTimeout = 20000;
+
   public void setKeystore(String keystore) {
     this.keystore = keystore;
   }
@@ -275,6 +279,14 @@ public class SelendroidConfiguration {
 
   public void setDeviceLog(boolean deviceLog) {
     this.deviceLog = deviceLog;
+  }
+
+  public long getServerStartTimeout() {
+    return serverStartTimeout;
+  }
+
+  public void setServerStartTimeout(long serverStartTimeout) {
+    this.serverStartTimeout = serverStartTimeout;
   }
 
   @Override

--- a/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
@@ -306,7 +306,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
                                            + e.getMessage());
     }
     long start = System.currentTimeMillis();
-    long startTimeOut = 20000;
+    long startTimeOut = serverConfiguration.getServerStartTimeout();
     long timemoutEnd = start + startTimeOut;
     while (device.isSelendroidRunning() == false) {
       if (timemoutEnd >= System.currentTimeMillis()) {


### PR DESCRIPTION
Self explanatory, allows a bit more freedom in how long to wait for the selendroid-server to start (especially if testing on slow devices)

Contribution on behalf of: Facebook
