### PR TITLE
Add viewport meta tag support for webview app

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
@@ -365,6 +365,11 @@ public class SelendroidWebDriver {
           // Geo location settings
           settings.setGeolocationEnabled(true);
           settings.setGeolocationDatabasePath("/data/data/selendroid");
+
+          // viewport meta tag support
+          settings.setUseWideViewPort(true);
+          settings.setLoadWithOverviewMode(true);
+
         } catch (Exception e) {
           SelendroidLogger.error("An error occured while configuring the web view", e);
         }


### PR DESCRIPTION
Since major Mobile web borwsers support viewport meta tag (<meta name="viewport" ...),
I think selendroid's webview app should support this feature.
