### PR TITLE
Added --help option to standalone-server

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - Cleaned up repetitive error handling in selendroid-server [#562](../../issues/562) 
 - Stop swallowing exception when waiting for instrumentation [#563](../../issues/563)
 - Allow selendroid-server start timeout to be passed on command line [#564](../../issues/564)
+- Added "-h" and" --help" options to selendroid-standalone-server.
 
 0.11.0
 ---

--- a/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
@@ -115,6 +115,9 @@ public class SelendroidConfiguration {
       names = "-serverStartTimeout")
   private long serverStartTimeout = 20000;
 
+  @Parameter(names = {"-h", "--help"}, description = "Prints usage instructions to the terminal")
+  private boolean printHelp = false;
+
   public void setKeystore(String keystore) {
     this.keystore = keystore;
   }
@@ -287,6 +290,14 @@ public class SelendroidConfiguration {
 
   public void setServerStartTimeout(long serverStartTimeout) {
     this.serverStartTimeout = serverStartTimeout;
+  }
+
+  public boolean isPrintHelp() {
+    return printHelp;
+  }
+
+  public void setPrintHelp(boolean printHelp) {
+    this.printHelp = printHelp;
   }
 
   @Override

--- a/selendroid-standalone/src/main/java/io/selendroid/SelendroidLauncher.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/SelendroidLauncher.java
@@ -83,26 +83,32 @@ public class SelendroidLauncher {
 
     System.out.println("################# Selendroid #################");
     SelendroidConfiguration config = new SelendroidConfiguration();
+    JCommander jCommander = null;
     try {
-      new JCommander(config, args);
+      jCommander = new JCommander(config, args);
+      jCommander.setProgramName("Selendroid Standalone Server");
     } catch (ParameterException e) {
       log.severe("An error occurred while starting selendroid: " + e.getMessage());
       System.exit(0);
     }
 
-    // Log the loaded configuration
-    System.out.println("################# Configuration in use #################");
-    System.out.println(config.toString());
-
-    //to be backward compatible
-    if (LogLevelEnum.ERROR.equals(config.getLogLevel())) {
-      Logger.getLogger(LOGGER_NAME).setLevel(LogLevelEnum.VERBOSE.level);
+    if (config.isPrintHelp()) {
+      jCommander.usage();
     } else {
-      Logger.getLogger(LOGGER_NAME).setLevel(config.getLogLevel().level);
-    }
+      // Log the loaded configuration
+      System.out.println("################# Configuration in use #################");
+      System.out.println(config.toString());
 
-    SelendroidLauncher laucher = new SelendroidLauncher(config);
-    laucher.launchServer();
+      //to be backward compatible
+      if (LogLevelEnum.ERROR.equals(config.getLogLevel())) {
+        Logger.getLogger(LOGGER_NAME).setLevel(LogLevelEnum.VERBOSE.level);
+      } else {
+        Logger.getLogger(LOGGER_NAME).setLevel(config.getLogLevel().level);
+      }
+
+      SelendroidLauncher laucher = new SelendroidLauncher(config);
+      laucher.launchServer();
+    }
   }
 
   private static void configureLogging() throws Exception {


### PR DESCRIPTION
Here's how it looks at the moment!

```
################# Selendroid #################
Usage: Selendroid Standalone Server [options]
  Options:
    -h, --help
       Prints usage instructions to the terminal
       Default: false
    -app, -aut
       location of the application under test. Absolute path to the apk
       Default: []
    -deviceLog
       Specifies whether or not adb logging should be enabled for the device
       running the test
       Default: true
    -deviceScreenshot
       if true, screenshots will be taken on the device instead of using the
       ddmlib libary.
       Default: false
    -emulatorOptions
       The emulator options used for starting emulators: e.g. -no-audio
    -emulatorPort
       port number to start running emulators on
       Default: 5560
    -forceReinstall
       Forces Selendroid Server and the app under test to be reinstalled (for
       Selendroid developers)
       Default: false
    -host
       host of the node. Ip address needs to be specified for registering to a
       grid hub (guessing can be wrong complex).
    -hub
       if specified, will send a registration request to the given url. Example
       : http://localhost:4444/grid/register
    -keepAdbAlive
       If true, adb will not be terminated on server shutdown.
       Default: false
    -keystore
       The file of the keystore to be used
    -keystoreAlias
       The alias of the keystore to be used
    -keystorePassword
       The password for the keystore to be used
    -logLevel
       Specifies the log level of selendroid. Available values are: ERROR,
       WARNING, INFO, DEBUG and VERBOSE.
       Default: ERROR
    -noClearData
       When you quit the app, shell pm clear will not be called with this option
       specified.
       Default: false
    -noWebviewApp
       If you don't want selendroid to auto-extract and have 'AndroidDriver'
       (webview only app) available.
       Default: false
    -port
       port the server will listen on.
       Default: 4444
    -proxy
       if specified, will specify the remote proxy to use on the grid. Example :
       io.selendroid.grid.SelendroidSessionProxy
    -selendroidServerPort
       the port the selendroid-standalone is using to communicate with
       instrumentation server
       Default: 8080
    -serverStartTimeout
       Maximum time in milliseconds to wait for the selendroid-server to come up
       on the device
       Default: 20000
    -sessionTimeout
       maximum session duration in seconds. Session will be forcefully
       terminated if it takes longer.
       Default: 1800
    -timeoutEmulatorStart
       timeout that will be used to start Android emulators
       Default: 300000
    -verbose
       Debug mode
       Default: false
```
