### PR TITLE
Report unhandled exceptions under instrumentation as AppCrashedException

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - Split up SelendroidLauncher main(), getInstance() can now be used to get a launcher programmatically.
 - Added capability to load in extension handlers and a test bootstrap class
 - Assume AUT is already installed if LaunchActivity specified & no matching appsStore entry [#567](../../issues/567)
+- Propagate unhandled exceptions in AUT as AppCrashedException
 
 0.11.0
 ---

--- a/selendroid-server-common/src/main/java/io/selendroid/server/model/ExternalStorageFile.java
+++ b/selendroid-server-common/src/main/java/io/selendroid/server/model/ExternalStorageFile.java
@@ -1,0 +1,20 @@
+package io.selendroid.server.model;
+
+public enum ExternalStorageFile {
+  APP_CRASH_LOG("appcrash.log");
+
+  private String fileName;
+
+  private ExternalStorageFile(String fileName) {
+    this.fileName = fileName;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  @Override
+  public String toString() {
+    return fileName;
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/ServerInstrumentation.java
+++ b/selendroid-server/src/main/java/io/selendroid/ServerInstrumentation.java
@@ -140,18 +140,21 @@ public class ServerInstrumentation extends Instrumentation implements ServerDeta
     SelendroidLogger.error("Error");
     SelendroidLogger.debug("debug");
     synchronized (ServerInstrumentation.class) {
-      try {
-        Context context = getTargetContext();
-        if (args.isLoadExtensions()) {
-          extensionLoader = new ExtensionLoader(context, ExternalStorage.getExtensionDex().getAbsolutePath());
-          String bootstrapClassNames = args.getBootstrapClassNames();
-          if (bootstrapClassNames != null) {
-            extensionLoader.runBootstrapClasses(this, bootstrapClassNames.split(","));
-          }
-        } else {
-          extensionLoader = new ExtensionLoader(context);
-        }
+      UncaughtExceptionHandling.clearCrashLogFile();
+      UncaughtExceptionHandling.setGlobalExceptionHandler();
 
+      Context context = getTargetContext();
+      if (args.isLoadExtensions()) {
+        extensionLoader = new ExtensionLoader(context, ExternalStorage.getExtensionDex().getAbsolutePath());
+        String bootstrapClassNames = args.getBootstrapClassNames();
+        if (bootstrapClassNames != null) {
+          extensionLoader.runBootstrapClasses(this, bootstrapClassNames.split(","));
+        }
+      } else {
+        extensionLoader = new ExtensionLoader(context);
+      }
+
+      try {
         startMainActivity();
         startServer();
       } catch (Exception e) {

--- a/selendroid-server/src/main/java/io/selendroid/UncaughtExceptionHandling.java
+++ b/selendroid-server/src/main/java/io/selendroid/UncaughtExceptionHandling.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid;
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import io.selendroid.server.model.ExternalStorage;
+import io.selendroid.util.SelendroidLogger;
+
+/**
+ * Reports uncaught exceptions to a crash log file on the device so the client can read them.
+ */
+public class UncaughtExceptionHandling {
+  /**
+   * Delete existing crash log file.
+   */
+  public static void clearCrashLogFile() {
+    ExternalStorage.getCrashLog().delete();
+  }
+
+  /**
+   * Handle uncaught exceptions by logging them to the crash log file, then kill the application.
+   */
+  public static void setGlobalExceptionHandler() {
+    Thread.setDefaultUncaughtExceptionHandler(new ExceptionDumper());
+  }
+
+  private static class ExceptionDumper implements Thread.UncaughtExceptionHandler {
+    @Override
+    public void uncaughtException(Thread thread, Throwable ex) {
+      File crashLogFile = ExternalStorage.getCrashLog();
+      String outputPath = crashLogFile.getAbsolutePath();
+
+      PrintWriter pw = null;
+      try {
+        pw = new PrintWriter(crashLogFile);
+        ex.printStackTrace(pw);
+        pw.flush();
+
+        SelendroidLogger.info("Process has crashed, log has been written to: " + outputPath);
+      } catch (Exception logEx) {
+        SelendroidLogger.error("Could not write crash log to: " + outputPath, logEx);
+      } finally {
+        if (pw != null) {
+          pw.close();
+        }
+      }
+
+      System.exit(-1);
+    }
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/ExternalStorage.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/ExternalStorage.java
@@ -33,4 +33,8 @@ public class ExternalStorage {
   public static File getExtensionDex() {
     return new File(getExternalStorageDir(), "extension.dex");
   }
+
+  public static File getCrashLog() {
+    return new File(getExternalStorageDir(), ExternalStorageFile.APP_CRASH_LOG.toString());
+  }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/android/AndroidDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/AndroidDevice.java
@@ -76,4 +76,6 @@ public interface AndroidDevice {
   public void restartADB();
 
   public String getExternalStoragePath();
+
+  public String getCrashLog();
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/impl/AbstractDevice.java
@@ -29,6 +29,7 @@ import io.selendroid.exceptions.AndroidSdkException;
 import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.exceptions.ShellCommandException;
 import io.selendroid.io.ShellCommand;
+import io.selendroid.server.model.ExternalStorageFile;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecuteResultHandler;
 import org.apache.commons.exec.DefaultExecutor;
@@ -46,6 +47,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
@@ -538,6 +540,19 @@ public abstract class AbstractDevice implements AndroidDevice {
 
   public String getExternalStoragePath() {
     return runAdbCommand("shell echo $EXTERNAL_STORAGE");
+  }
+
+  /**
+   * Get crash log from AUT
+   * @return empty string if there is no crash log on the device, otherwise returns the stack trace
+   * caused by the crash of the AUT
+   */
+  public String getCrashLog() {
+    String crashLogFile = ExternalStorageFile.APP_CRASH_LOG.toString();
+    String crashLogPath = new File(getExternalStoragePath(), crashLogFile).getAbsolutePath();
+    CommandLine command = adbCommand("shell", "test", "-e", crashLogPath, "&&", "cat", crashLogPath);
+
+    return executeCommandQuietly(command);
   }
 
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
@@ -14,6 +14,7 @@
 package io.selendroid.server.handler;
 
 import io.selendroid.android.AndroidDevice;
+import io.selendroid.exceptions.AppCrashedException;
 import io.selendroid.exceptions.SelendroidException;
 import io.selendroid.server.BaseSelendroidServerHandler;
 import io.selendroid.server.Response;
@@ -67,6 +68,12 @@ public class RequestRedirectHandler extends BaseSelendroidServerHandler {
       } catch (Exception e) {
         if (retries == 0) {
           AndroidDevice device = session.getDevice();
+
+          String crashMessage = device.getCrashLog();
+          if (!crashMessage.isEmpty()) {
+            return new SelendroidResponse(sessionId, StatusCode.UNKNOWN_ERROR, new AppCrashedException(crashMessage));
+          }
+
           if (device.isLoggingEnabled()) {
             log.info("getting logs");
             device.setVerbose();
@@ -74,6 +81,7 @@ public class RequestRedirectHandler extends BaseSelendroidServerHandler {
               System.out.println(le.getMessage());
             }
           }
+
           return new SelendroidResponse(sessionId, StatusCode.UNKNOWN_ERROR,
                   new SelendroidException(
                           "Error occured while communicating with selendroid server on the device: ",


### PR DESCRIPTION
This change dumps unhandled exceptions in the application to a file on the device which can be checked in the cases of selendroid-server not coming up or failing to respond to a command.

This way we can report AppCrashedExceptions to the driver reliably so that bugs are easier to triage.
