### PR TITLE
Changed usages of org.jboss to io.netty. Avoids unnecessary dependency

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/InspectorTreeHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/InspectorTreeHandler.java
@@ -23,7 +23,7 @@ import io.selendroid.server.util.HttpClientUtil;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.jboss.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpMethod;
 import org.json.JSONException;
 import io.selendroid.server.http.HttpRequest;
 

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/NetworkConnectionHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/NetworkConnectionHandler.java
@@ -1,16 +1,14 @@
 package io.selendroid.server.handler;
 
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.android.AndroidDevice;
 import io.selendroid.android.KeyEvent;
 import io.selendroid.android.impl.DefaultAndroidEmulator;
-import io.selendroid.device.DeviceTargetPlatform;
 import io.selendroid.server.BaseSelendroidServerHandler;
 import io.selendroid.server.Response;
 import io.selendroid.server.SelendroidResponse;
 import io.selendroid.server.model.ActiveSession;
 import io.selendroid.server.util.HttpClientUtil;
-import org.apache.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.json.JSONException;
 import org.json.JSONObject;
 import io.selendroid.server.http.HttpRequest;

--- a/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/handler/RequestRedirectHandler.java
@@ -13,6 +13,7 @@
  */
 package io.selendroid.server.handler;
 
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.android.AndroidDevice;
 import io.selendroid.exceptions.AppCrashedException;
 import io.selendroid.exceptions.SelendroidException;
@@ -23,7 +24,6 @@ import io.selendroid.server.StatusCode;
 import io.selendroid.server.model.ActiveSession;
 import io.selendroid.server.util.HttpClientUtil;
 import org.apache.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openqa.selenium.logging.LogEntry;

--- a/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/model/SelendroidStandaloneDriver.java
@@ -13,6 +13,7 @@
  */
 package io.selendroid.server.model;
 
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.SelendroidCapabilities;
 import io.selendroid.SelendroidConfiguration;
 import io.selendroid.android.AndroidApp;
@@ -42,7 +43,6 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/selendroid-standalone/src/main/java/io/selendroid/server/util/HttpClientUtil.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/util/HttpClientUtil.java
@@ -14,6 +14,8 @@
 package io.selendroid.server.util;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.SelendroidCapabilities;
 
 import java.util.logging.Logger;
@@ -29,7 +31,6 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHttpEntityEnclosingRequest;
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -45,7 +46,7 @@ public class HttpClientUtil {
   public static HttpResponse executeRequestWithPayload(String uri, int port, HttpMethod method,
       String payload) throws Exception {
     BasicHttpEntityEnclosingRequest request =
-        new BasicHttpEntityEnclosingRequest(method.getName(), uri);
+        new BasicHttpEntityEnclosingRequest(method.name(), uri);
     request.setEntity(new StringEntity(payload, "UTF-8"));
 
     return getHttpClient().execute(new HttpHost("localhost", port), request);

--- a/selendroid-standalone/src/test/java/io/selendroid/android/impl/DefaultHardwareDeviceTests.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/android/impl/DefaultHardwareDeviceTests.java
@@ -14,6 +14,7 @@
 package io.selendroid.android.impl;
 
 import com.android.ddmlib.IDevice;
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.SelendroidCapabilities;
 import io.selendroid.android.AndroidApp;
 import io.selendroid.android.AndroidDevice;
@@ -23,7 +24,6 @@ import io.selendroid.server.util.HttpClientUtil;
 import io.selendroid.util.SelendroidAssert;
 import org.apache.commons.exec.CommandLine;
 import org.apache.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/selendroid-standalone/src/test/java/io/selendroid/server/SelendroidStatusHandlerTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/server/SelendroidStatusHandlerTest.java
@@ -15,6 +15,8 @@ package io.selendroid.server;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.SelendroidConfiguration;
 import io.selendroid.exceptions.AndroidSdkException;
 import io.selendroid.server.model.SelendroidStandaloneDriver;
@@ -22,7 +24,6 @@ import io.selendroid.server.util.HttpClientUtil;
 import io.selendroid.util.SelendroidAssert;
 
 import org.apache.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -31,7 +32,7 @@ import org.junit.BeforeClass;
 /**
  * TODO ddary: revisit when looking at buck
  */
-public class SelendroidSatusHandlerTest {
+public class SelendroidStatusHandlerTest {
   protected static int port = 7777;
   private static SelendroidStandaloneServer server;
   public static final String URL = "http://localhost:" + port + "/wd/hub/status";

--- a/selendroid-standalone/src/test/java/io/selendroid/server/support/DeviceForTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/server/support/DeviceForTest.java
@@ -14,6 +14,7 @@
 package io.selendroid.server.support;
 
 import com.android.ddmlib.IDevice;
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.SelendroidCapabilities;
 import io.selendroid.android.AndroidApp;
 import io.selendroid.android.impl.DefaultAndroidEmulator;
@@ -22,7 +23,6 @@ import io.selendroid.exceptions.AndroidDeviceException;
 import io.selendroid.exceptions.AndroidSdkException;
 import io.selendroid.server.util.HttpClientUtil;
 import org.apache.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.json.JSONObject;
 import org.openqa.selenium.logging.LogEntry;
 

--- a/selendroid-test-app/src/test/java/io/selendroid/driver/MultipleWebviewHandlingTests.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/driver/MultipleWebviewHandlingTests.java
@@ -14,15 +14,15 @@
 package io.selendroid.driver;
 
 import static io.selendroid.waiter.TestWaiter.waitFor;
+
+import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.SelendroidDriver;
-import io.selendroid.exceptions.NoSuchContextException;
 import io.selendroid.server.util.HttpClientUtil;
 import io.selendroid.support.BaseAndroidTest;
 import io.selendroid.waiter.WaitingConditions;
 
 import java.util.Set;
 
-import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;


### PR DESCRIPTION
changes usages of org.jboss.netty.handler.codec.http.HttpMethod to io.netty.handler.codec.http.HttpMethod.

Not sure why we used the former before, but it avoids depending on stuff outside the io.netty package
