### PR TITLE
Set missing selendroid basic capabilities

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/SelendroidCapabilities.java
@@ -194,11 +194,12 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   }
 
   public SelendroidCapabilities(String aut) {
+    this();
     setAut(aut);
   }
 
   public SelendroidCapabilities(String serial, String aut) {
-    setAut(aut);
+    this(aut);
     setSerial(serial);
     if (serial == null) {
       setEmulator(null);


### PR DESCRIPTION
I found that SelendroidCapabilities(String aut) and SelendroidCapabilities(String serial, String aut) constructors don't set basic selendroid capabilities that set by default constructor (browserName, platformName and autonationName).

I'm not sure this is a bug or not.

If it's a bug, please pull this PR.

Not that if merge this PR, grid documentation (http://selendroid.io/scale.html) should also be update to
include "platformName" capability for selendroid capabilities like as follows:

<pre>
      "browserName": "selendroid",      
      "platformName": "android",      
      "maxInstances": 1,
      "aut": "io.selendroid.testapp:0.11.0"
  </pre>


Regards.
