### PR TITLE
Fix connection reset bug - adds Connection: close header

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 - Changed getScreenSize() to use Dimension instead of string,
   added support for emulators with string skin names
 - Fixed loading of keystores with no password
+- Send connection: close header in responses. Fixes [#458](../../issues/458)
 
 
 0.11.0

--- a/selendroid-server-common/src/main/java/io/selendroid/server/http/ServerHandler.java
+++ b/selendroid-server-common/src/main/java/io/selendroid/server/http/ServerHandler.java
@@ -44,6 +44,7 @@ public class ServerHandler extends ChannelInboundHandlerAdapter {
 
     FullHttpRequest request = (FullHttpRequest) msg;
     FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK);
+    response.headers().add("Connection", "close");
 
     HttpRequest httpRequest = new NettyHttpRequest(request);
     HttpResponse httpResponse = new NettyHttpResponse(response);


### PR DESCRIPTION
We close the connection after every request (Will consider adding pipelining later).

But as we close every connection and are using HTTP/1.1, we have to send the "Connection: close" header or else clients will try to use the already dead connection and get connection reset.
