### PR TITLE
Standardises vendor-specific urls for selendroid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 - Lowered severity of logs in isSelendroidRunning(), made messages more informative.
 - Made E2E tests use SelendroidStandaloneServer
 - findElements() returns an empty list instead of throwing an exception.
+- Standardises URLs / makes them compliant with the WebDriver specification
 
 0.11.0
 ---

--- a/selendroid-client/src/main/java/io/selendroid/SelendroidCommandExecutor.java
+++ b/selendroid-client/src/main/java/io/selendroid/SelendroidCommandExecutor.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SelendroidCommandExecutor extends HttpCommandExecutor {
-
+  private final static String VENDOR_PREFIX = "/session/:sessionId/selendroid/";
   private final static Map<String, CommandInfo> SELENDROID_COMMANDS =
       new HashMap<String, CommandInfo>() {
         {
@@ -32,39 +32,39 @@ public class SelendroidCommandExecutor extends HttpCommandExecutor {
               HttpMethod.GET));
           put("setNetworkConnection", new CommandInfo("/session/:sessionId/network_connection",
                   HttpMethod.POST));
-          put("selendroid-getBrightness", new CommandInfo(
-              "-selendroid/:sessionId/screen/brightness", HttpMethod.GET));
-          put("selendroid-setBrightness", new CommandInfo(
-              "-selendroid/:sessionId/screen/brightness", HttpMethod.POST));
-          put("selendroid-getCommandConfiguration", new CommandInfo(
-              "-selendroid/:sessionId/configure/command/:command", HttpMethod.GET));
-          put("selendroid-setCommandConfiguration", new CommandInfo(
-              "-selendroid/:sessionId/configure/command/:command", HttpMethod.POST));
-          put("selendroid-adb-sendKeyEvent", new CommandInfo(
-              "-selendroid/:sessionId/adb/sendKeyEvent", HttpMethod.POST));
-          put("selendroid-adb-sendText", new CommandInfo("-selendroid/:sessionId/adb/sendText",
-                  HttpMethod.POST));
-          put("selendroid-adb-tap",
-              new CommandInfo("-selendroid/:sessionId/adb/tap", HttpMethod.POST));
-          put("selendroid-adb-executeShellCommand",
-            new CommandInfo("-selendroid/:sessionId/adb/executeShellCommand", HttpMethod.POST));
-          put("selendroid-handleByExtension",
-              new CommandInfo("/session/:sessionId/-selendroid/extension", HttpMethod.POST));
-          put("backgroundApp",
-            new CommandInfo("/session/:sessionId/-selendroid/background", HttpMethod.POST));
-          put("resumeApp",
-            new CommandInfo("/session/:sessionId/-selendroid/resume", HttpMethod.POST));
-          put("addCallLog",
-            new CommandInfo("/session/:sessionId/-selendroid/addcalllog",HttpMethod.POST));
-          put("readCallLog",
-            new CommandInfo("/session/:sessionId/-selendroid/readcalllog",HttpMethod.POST));
           put("actions", new CommandInfo("/session/:sessionId/actions", HttpMethod.POST));
-          put("-selendroid-forceGcExplicitly",
-              new CommandInfo("/session/:sessionId/-selendroid/gc", HttpMethod.POST));
+
+          put("selendroid-getBrightness", newVendorCommand("screen/brightness", HttpMethod.GET));
+          put("selendroid-setBrightness", newVendorCommand("screen/brightness", HttpMethod.POST));
+
+          put("selendroid-getCommandConfiguration",
+                  newVendorCommand("configure/command/:command", HttpMethod.GET));
+          put("selendroid-setCommandConfiguration",
+                  newVendorCommand("configure/command/:command", HttpMethod.POST));
+
+          put("selendroid-adb-sendKeyEvent",newVendorCommand("adb/sendKeyEvent", HttpMethod.POST));
+          put("selendroid-adb-sendText", newVendorCommand("adb/sendText", HttpMethod.POST));
+          put("selendroid-adb-tap", newVendorCommand("adb/tap", HttpMethod.POST));
+          put("selendroid-adb-executeShellCommand",
+                  newVendorCommand("adb/executeShellCommand", HttpMethod.POST));
+
+          put("selendroid-handleByExtension", newVendorCommand("extension", HttpMethod.POST));
+
+          put("backgroundApp", newVendorCommand("background", HttpMethod.POST));
+          put("resumeApp", newVendorCommand("resume", HttpMethod.POST));
+
+          put("addCallLog", newVendorCommand("addCallLog", HttpMethod.POST));
+          put("readCallLog", newVendorCommand("readCallLog", HttpMethod.POST));
+
+          put("-selendroid-forceGcExplicitly", newVendorCommand("gc", HttpMethod.POST));
           put("-selendroid-setAndroidOsSystemProperty",
-              new CommandInfo("/session/:sessionId/-selendroid/system_property", HttpMethod.POST));
+                  newVendorCommand("systemProperty", HttpMethod.POST));
         }
       };
+
+  private static CommandInfo newVendorCommand(String path, HttpMethod method) {
+    return new CommandInfo(VENDOR_PREFIX + path, method);
+  }
 
   public SelendroidCommandExecutor(URL url) throws MalformedURLException {
     super(SELENDROID_COMMANDS, url);

--- a/selendroid-server/src/main/java/io/selendroid/server/AndroidServlet.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/AndroidServlet.java
@@ -183,27 +183,27 @@ public class AndroidServlet extends BaseServlet {
     register(postHandler, new SwitchContext("/wd/hub/session/:sessionId/context"));
 
     // Custom extensions to wire protocol
-    register(getHandler, new GetScreenState("/wd/hub/-selendroid/:sessionId/screen/brightness"));
-    register(postHandler, new SetScreenState("/wd/hub/-selendroid/:sessionId/screen/brightness"));
+    register(getHandler, new GetScreenState("/wd/hub/session/:sessionId/selendroid/screen/brightness"));
+    register(postHandler, new SetScreenState("/wd/hub/session/:sessionId/selendroid/screen/brightness"));
     register(postHandler, new InspectorTap("/wd/hub/session/:sessionId/tap/2"));
     register(getHandler, new GetCommandConfiguration(
-        "/wd/hub/-selendroid/:sessionId/configure/command/:command"));
+        "/wd/hub/session/:sessionId/selendroid/configure/command/:command"));
     register(postHandler, new SetCommandConfiguration(
-        "/wd/hub/-selendroid/:sessionId/configure/command/:command"));
-    register(postHandler, new ForceGcExplicitly("/wd/hub/session/:sessionId/-selendroid/gc"));
-    register(postHandler, new SetSystemProperty("/wd/hub/session/:sessionId/-selendroid/system_property"));
+        "/wd/hub/session/:sessionId/selendroid/configure/command/:command"));
+    register(postHandler, new ForceGcExplicitly("/wd/hub/session/:sessionId/selendroid/gc"));
+    register(postHandler, new SetSystemProperty("/wd/hub/session/:sessionId/selendroid/systemProperty"));
 
     // Endpoints to send app to background and resume it
-    register(postHandler, new BackgroundApp("/wd/hub/session/:sessionId/-selendroid/background"));
-    register(postHandler, new ResumeApp("/wd/hub/session/:sessionId/-selendroid/resume"));
+    register(postHandler, new BackgroundApp("/wd/hub/session/:sessionId/selendroid/background"));
+    register(postHandler, new ResumeApp("/wd/hub/session/:sessionId/selendroid/resume"));
 
     // Endpoints to add to and read call logs
-    register(postHandler, new AddCallLog("/wd/hub/session/:sessionId/-selendroid/addcalllog"));
-    register(postHandler, new ReadCallLog("/wd/hub/session/:sessionId/-selendroid/readcalllog"));
+    register(postHandler, new AddCallLog("/wd/hub/session/:sessionId/selendroid/addCallLog"));
+    register(postHandler, new ReadCallLog("/wd/hub/session/:sessionId/selendroid/readCallLog"));
 
     // Handle calls to dynamically loaded handlers
     register(postHandler, new ExtensionCallHandler(
-        "/wd/hub/session/:sessionId/-selendroid/extension", extensionLoader));
+        "/wd/hub/session/:sessionId/selendroid/extension", extensionLoader));
 
     // Actions sequencing endpoint
     register(postHandler, new Actions("/wd/hub/session/:sessionId/actions"));

--- a/selendroid-standalone/src/main/java/io/selendroid/server/SelendroidServlet.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/SelendroidServlet.java
@@ -72,11 +72,11 @@ public class SelendroidServlet extends BaseServlet {
     register(redirectHandler, new RequestRedirectHandler("/wd/hub/session/"));
 
     register(postHandler, new GetLogs("/wd/hub/session/:sessionId/log"));
-    register(postHandler, new AdbSendKeyEvent("/wd/hub/-selendroid/:sessionId/adb/sendKeyEvent"));
-    register(postHandler, new AdbSendText("/wd/hub/-selendroid/:sessionId/adb/sendText"));
-    register(postHandler, new AdbTap("/wd/hub/-selendroid/:sessionId/adb/tap"));
+    register(postHandler, new AdbSendKeyEvent("/wd/hub/session/:sessionId/selendroid/adb/sendKeyEvent"));
+    register(postHandler, new AdbSendText("/wd/hub/session/:sessionId/selendroid/adb/sendText"));
+    register(postHandler, new AdbTap("/wd/hub/session/:sessionId/selendroid/adb/tap"));
     register(postHandler, new AdbExecuteShellCommand(
-        "/wd/hub/-selendroid/:sessionId/adb/executeShellCommand"));
+        "/wd/hub/session/:sessionId/selendroid/adb/executeShellCommand"));
     register(postHandler, new NetworkConnectionHandler("/wd/hub/session/:sessionId/network_connection"));
   }
 


### PR DESCRIPTION
Standardises our selendroid vendor specific urls based on https://dvcs.w3.org/hg/webdriver/raw-file/default/webdriver-spec.html#extending-the-json-http-protocol
