### PR TITLE
Add lightweight instrumentation into manifest

### DIFF
--- a/selendroid-server/AndroidManifest.xml
+++ b/selendroid-server/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-sdk android:minSdkVersion="10"/>
 
     <instrumentation android:name="io.selendroid.ServerInstrumentation" android:targetPackage="io.selendroid.testapp"/>
+    <instrumentation android:name="io.selendroid.LightweightInstrumentation" android:targetPackage="io.selendroid.testapp"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/selendroid-standalone/AndroidManifestTemplate.xml
+++ b/selendroid-standalone/AndroidManifestTemplate.xml
@@ -4,6 +4,7 @@
     <uses-sdk android:minSdkVersion="10"/>
 
     <instrumentation android:name="io.selendroid.ServerInstrumentation" android:targetPackage="io.selendroid.testapp"/>
+    <instrumentation android:name="io.selendroid.LightweightInstrumentation" android:targetPackage="io.selendroid.testapp"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
Otherwise it could not be recognized and causes error if people try to use it

This should be part of pill request #608 and followup change for commit https://github.com/selendroid/selendroid/commit/1449e0320fd5923910c98c2f871721aca1f9b5e9
