### PR TITLE
Fixed updating device in device store

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/server/model/DeviceStore.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/model/DeviceStore.java
@@ -146,7 +146,7 @@ public class DeviceStore {
     for (DeviceTargetPlatform targetPlatform : androidDevices.keySet()) {
       List<AndroidDevice> platformDevices = androidDevices.get(targetPlatform);
       // Attempt to remove the device from this target platform;
-      deviceRemoved = platformDevices.remove(device);
+      deviceRemoved |= platformDevices.remove(device);
     }
 
     if (deviceRemoved) {

--- a/selendroid-standalone/src/test/java/io/selendroid/server/model/DeviceStoreFixture.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/server/model/DeviceStoreFixture.java
@@ -13,6 +13,10 @@
  */
 package io.selendroid.server.model;
 
+import com.android.ddmlib.IDevice;
+
+import java.util.Map;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import io.selendroid.SelendroidCapabilities;
@@ -33,6 +37,15 @@ public class DeviceStoreFixture {
 
     return device;
   }
+
+  protected static DefaultHardwareDevice anDevice(String serial, Map<String, String> prop)
+      throws AndroidDeviceException {
+    IDevice device = mock(IDevice.class);
+    when(device.getSerialNumber()).thenReturn(serial);
+
+    return new FakeHardwareDevice(device, prop);
+  }
+
 
   protected static DefaultAndroidEmulator anEmulator(String name, DeviceTargetPlatform platform,
       boolean isEmulatorStarted) throws AndroidDeviceException {
@@ -58,5 +71,17 @@ public class DeviceStoreFixture {
     when(finder.getVirtualDevice("emulator-5554")).thenReturn(null);
 
     return finder;
+  }
+
+  static class FakeHardwareDevice extends DefaultHardwareDevice {
+    private Map<String, String> prop;
+    public FakeHardwareDevice(IDevice device, Map<String, String> prop) {
+      super(device);
+      this.prop = prop;
+    }
+    @Override
+    public String getProp(String name) {
+      return prop.get(name);
+    }
   }
 }


### PR DESCRIPTION
I found that selendroid fails to add hardware device dynamically when one or more devices are already exist in device store.

This PR fixes this problem.

I also added update and remove device test.

Regards.
