### PR TITLE
Added folder monitoring capability and fixed emulator launching problem.

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/SelendroidConfiguration.java
@@ -20,6 +20,7 @@ import io.selendroid.log.LogLevelEnum;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -131,6 +132,9 @@ public class SelendroidConfiguration {
   @Parameter(names="-serverStartRetries",
              description="Maximum amount of times the starting of the selendroid-server on the device will be retried")
   private int serverStartRetries = 5;
+
+  @Parameter(names = "-folder", description = "The folder which contains Android applications under test. This folder will monitor and add new apps to the apps store during the lifetime of the selendroid node.")
+  private String folder = null;
 
   public void setKeystore(String keystore) {
     this.keystore = keystore;
@@ -350,6 +354,10 @@ public class SelendroidConfiguration {
 
   public void setMaxInstances(int maxInstances) {
     this.maxInstances = maxInstances;
+  }
+
+  public String getAppFolderToMonitor() {
+    return folder;
   }
 
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/android/impl/DefaultAndroidEmulator.java
@@ -278,8 +278,18 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
     }
     setSerial(emulatorPort);
     Boolean adbKillServerAttempted = false;
-    while (!isDeviceReady()) {
 
+    // Without this one seconds, the call to "isDeviceReady" is
+    // too quickly sent while the emulator is still starting and
+    // not ready to receive any commands. Because of this the
+    // while loops failed and sometimes hung in isDeviceReady function.
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    while (!isDeviceReady()) {
       if (!adbKillServerAttempted && System.currentTimeMillis() - start > 10000) {
         CommandLine adbDevicesCmd = new CommandLine(AndroidSdk.adb());
         adbDevicesCmd.addArgument("devices", false);

--- a/selendroid-standalone/src/main/java/io/selendroid/server/util/FolderMonitor.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/server/util/FolderMonitor.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2012-2013 eBay Software Foundation and selendroid committers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.selendroid.server.util;
+
+import io.selendroid.SelendroidConfiguration;
+import io.selendroid.exceptions.AndroidSdkException;
+import io.selendroid.server.model.SelendroidStandaloneDriver;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.logging.Logger;
+
+public class FolderMonitor implements Runnable {
+
+  private static final Logger log = Logger.getLogger(FolderMonitor.class.getName());
+  private SelendroidConfiguration selendroidConfiguration;
+  private SelendroidStandaloneDriver selendroidStandaloneDriver;
+  private WatchService folderWatcher;
+  private final Object stoppedLock;
+  private boolean stopped;
+  private Thread thread;
+
+  public FolderMonitor(SelendroidStandaloneDriver selendroidStandaloneDriver, SelendroidConfiguration selendroidConfiguration)
+      throws IOException {
+    this.selendroidStandaloneDriver = selendroidStandaloneDriver;
+    this.selendroidConfiguration = selendroidConfiguration;
+    stoppedLock = new Object();
+    stopped = false;
+    init();
+    folderWatcher = FileSystems.getDefault().newWatchService();
+    Path watchedFolder = Paths.get(selendroidConfiguration.getAppFolderToMonitor());
+    try {
+      watchedFolder.register(folderWatcher, StandardWatchEventKinds.ENTRY_CREATE,
+                             StandardWatchEventKinds.ENTRY_MODIFY,
+                             StandardWatchEventKinds.ENTRY_DELETE);
+    } catch (NoSuchFileException e) {
+      stop();
+      log.warning("invalid location: " + new File(selendroidConfiguration.getAppFolderToMonitor())
+          .getAbsolutePath());
+    }
+  }
+
+  private void init() {
+    File[] listOfFiles = new File(selendroidConfiguration.getAppFolderToMonitor()).listFiles();
+    if (listOfFiles == null) {
+      return;
+    }
+    for (File file : listOfFiles) {
+      if (isResigned(file)) {
+          file.delete();
+      } else if (isApp(file)) {
+        addApplication(file);
+      }
+    }
+  }
+
+  @Override
+  public void run() {
+    synchronized (stoppedLock) {
+      while (!stopped) {
+        checkForChanges();
+        try {
+          stoppedLock.wait(1000, 0);
+        } catch (InterruptedException ignore) {
+        }
+      }
+    }
+  }
+
+  private void checkForChanges() {
+    final WatchKey key = folderWatcher.poll();
+
+    if (key != null) {
+      for (WatchEvent<?> watchEvent : key.pollEvents()) {
+        final Path filePath = (Path) watchEvent.context();
+        final WatchEvent.Kind<?> kind = watchEvent.kind();
+        log.fine(kind + " : " + filePath);
+        handleFileChange(kind,
+                         new File(selendroidConfiguration.getAppFolderToMonitor(),
+                                  filePath.getFileName().toString()));
+      }
+
+      boolean valid = key.reset();
+      if (!valid) {
+        log.warning("Cannot monitor this folder anymore. Has it been deleted?");
+        stop();
+      }
+    }
+  }
+
+  private void handleFileChange(WatchEvent.Kind kind, File file) {
+    if (kind.equals(StandardWatchEventKinds.ENTRY_CREATE)) {
+      if (isApp(file)) {
+        // new file but only added to the list only 
+        // if they are not a resigned files.
+        if(!isResigned(file)) {
+            log.info("New app found! " + file.getName());
+            addToAppStore(file);
+        }
+      }
+    } else if (kind.equals(StandardWatchEventKinds.ENTRY_MODIFY)) {
+      log.info("App modified - no handler implemented!");
+    } else if (kind.equals(StandardWatchEventKinds.ENTRY_DELETE)) {
+      log.info("App deleted - no handler implemented!");
+    }
+  }
+
+  private void addApplication(File file) {
+    String app;
+    if (isApp(file)) {
+      if (!isResigned(file)) {
+        app = file.getAbsolutePath();
+        selendroidConfiguration.addSupportedApp(app);
+        log.info("File added to supported list:\n\t" + app);
+      }
+    }
+  }
+
+  private void addToAppStore(File file) {
+    String app;
+    if (isApp(file)) {
+      app = file.getAbsolutePath();
+      try {
+        selendroidStandaloneDriver.addToAppsStore(file);
+        log.info("File added to app store:\n\t" + app);
+      }catch (AndroidSdkException e) {
+        log.info("An error occurred while accessing the details of'" + file.getName()
+                + "'. ");
+      }
+    }
+  }
+
+  private boolean isApp(File file) {
+    if (file != null) {
+      return file.getAbsolutePath().endsWith(".apk");
+    }
+    return false;
+  }
+
+  private boolean isResigned(File file) {
+    return (isApp(file) && file.getAbsolutePath().contains("resigned"));
+  }
+
+  public void start() {
+    thread = new Thread(this);
+    thread.start();
+  }
+
+  public void stop() {
+    synchronized (stoppedLock) {
+      stopped = true;
+    }
+    try {
+      if (thread != null) {
+        thread.join();
+        thread = null;
+      }
+    } catch (InterruptedException ignore) {
+    }
+  }
+}


### PR DESCRIPTION
- The folder monitoring allows users to add one or more native android
  apps on fly and selendroid immediately signs and adds these files to
  the app store so they can be used without restarting the node.
- Adding one seconds wait before calling "isDeviceReady" to avoid the
  command sent too quickly while the emulator still starting and not ready
  to receive any commands

Signed-off-by: Binh Vu bvu@paypal.com
