### PR TITLE
Split app name and version in Capabilities.

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
@@ -28,6 +28,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM;
@@ -327,4 +330,40 @@ public class SelendroidCapabilities extends DesiredCapabilities {
     }
     return copy;
   }
+
+  /**
+   * Returns the application under test in the format of "appName:appVersion", or "appName" if the supported application
+   * does not have any version associated with it, or returns null if the requested app is not in the apps store. If the
+   * launch activity is also specified with requested application then just return the requested application as app under
+   * test so it can be later installed to the device by SelendroidStandaloneDriver.
+   *
+   * @param supportedApps The list of supported apps in the apps store.
+   * @return The application under test in "appName" or "appName:appVersion" format, or null if the application is not
+   *         in the list of supported apps and the launch activity is not specified.
+   */
+  public String getDefaultApp(Set<String> supportedApps) {
+    String defaultApp = getAut();
+    // if the launch activity is specified, just return.
+    if (getLaunchActivity() != null) {
+      return defaultApp;
+    }
+    // App version is not specified. Get the latest version from the apps store.
+    if (!defaultApp.contains(":")) {
+      return getDefaultVersion(supportedApps, defaultApp);
+    }
+    return supportedApps.contains(defaultApp) ? defaultApp : null;
+  }
+
+  // Go through the supported apps in the apps store to return the
+  // the latest version of the app.
+  private String getDefaultVersion(Set<String> keys, String appName) {
+    SortedSet<String> listOfApps = new TreeSet<String>();
+    for (String key : keys) {
+      if (key.split(":")[0].contentEquals(appName)) {
+        listOfApps.add(key);
+      }
+    }
+    return listOfApps.size() > 0 ? listOfApps.last() : null;
+  }
+
 }

--- a/selendroid-common/src/test/java/io/selendroid/common/SelendroidCapabilitiesGetDefaultAppTest.java
+++ b/selendroid-common/src/test/java/io/selendroid/common/SelendroidCapabilitiesGetDefaultAppTest.java
@@ -1,0 +1,118 @@
+package io.selendroid.common;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.selendroid.common.SelendroidCapabilities;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Makes sure that the new function "getDefaultApp" will return the correct application under test from the apps store
+ * or peacefully returns null if the app is not in the apps store. If the laucch activity is also specified with appName
+ * then just return the appName so it can be installed to the apps store.
+ *
+ * The tests will cover these scenarios:
+ * <ul>
+ *
+ * <li>If app does not exists in the apps store and the launch activity is specified, then just return
+ * the request string as app under test so it can be installed to the device by the SelendroidStandaloneDriver. </li>
+ * <li>If app does not exists in the appstore, and the launch activity is not specified then return null.</li>
+ * <li>If appName and appVersion are specified then return the app under test as "appName:appVersion" if it is found in the
+ * apps store or null if it is not.</li>
+ * <li>If appName is specified but not the appVersion then return the latest version of the apps in the apps store as app
+ * under test in the format of "appName:appVersion" or null if app is not found in apps store.</li>
+ * </li>
+ * <ul>
+ */
+public class SelendroidCapabilitiesGetDefaultAppTest {
+  // Unsorted List of String represents supported apps in the apps store.
+  private static final String elements[] = { "selendroid",
+            "io.selendroid.test", "io.selendroid.test:0.12.1",
+            "io.selendroid.test:0.11.1", "io.selendroid.test:0.11.0",
+            "io.selendroid.test:0.12.0", };
+  private static final Set supportedApps = new HashSet(Arrays.asList(elements));
+
+  @Test
+  public void testShouldReturnAppWithSpecifiedLaunchActivityEvenIfNotInStore() throws Exception {
+    JSONObject jsonSource = new JSONObject();
+    // app is not in store
+    jsonSource.put("aut", "io.selendroid.test:0.13.0");
+    jsonSource.put("launchActivity", "HomeScreenActivity");
+
+    SelendroidCapabilities capa = new SelendroidCapabilities(jsonSource);
+
+    String defaultApp = capa.getDefaultApp(supportedApps);
+    Assert.assertEquals("io.selendroid.test:0.13.0", defaultApp);
+  }
+
+  @Test
+  public void testReturnsTheLatestVersionOfApp() throws Exception {
+    JSONObject jsonSource = new JSONObject();
+    jsonSource.put("aut", "io.selendroid.test");
+
+    SelendroidCapabilities capa = new SelendroidCapabilities(jsonSource);
+
+    String defaultApp = capa.getDefaultApp(supportedApps);
+    Assert.assertEquals("io.selendroid.test:0.12.1", defaultApp);
+  }
+
+  @Test
+  public void testReturnsAnExactMatchWithoutSpecifiedVersion() throws Exception {
+    JSONObject jsonSource = new JSONObject();
+    jsonSource.put("aut", "selendroid");
+
+    SelendroidCapabilities capa = new SelendroidCapabilities(jsonSource);
+
+    String defaultApp = capa.getDefaultApp(supportedApps);
+    Assert.assertEquals("selendroid", defaultApp);
+  }
+
+  @Test
+  public void testReturnsAnExactMatchWithSpecifiedVersion() throws Exception {
+    JSONObject jsonSource = new JSONObject();
+    jsonSource.put("aut", "io.selendroid.test:0.11.0");
+
+    SelendroidCapabilities capa = new SelendroidCapabilities(jsonSource);
+
+    String defaultApp = capa.getDefaultApp(supportedApps);
+    Assert.assertEquals("io.selendroid.test:0.11.0", defaultApp);
+  }
+
+  @Test
+  public void testReturnsNullIfNoMatchingAppFound() throws Exception {
+    JSONObject jsonSource = new JSONObject();
+    jsonSource.put("aut", "io.selendroid.test2");
+
+    SelendroidCapabilities capa = new SelendroidCapabilities(jsonSource);
+
+    String defaultApp = capa.getDefaultApp(supportedApps);
+    Assert.assertNull(defaultApp);
+  }
+
+  @Test
+  public void testReturnsNullIfOnlyVersionIsSpecified() throws Exception {
+    JSONObject jsonSource = new JSONObject();
+    jsonSource.put("aut", "0.12.0");
+
+    SelendroidCapabilities capa = new SelendroidCapabilities(jsonSource);
+
+    String defaultApp = capa.getDefaultApp(supportedApps);
+    Assert.assertNull(defaultApp);
+  }
+
+  @Test
+  public void testResturnsNullIfAppAndVersionNotFound() throws Exception {
+    JSONObject jsonSource = new JSONObject();
+    jsonSource.put("aut", "io.selendroid.test:0.13.0");
+
+    SelendroidCapabilities capa = new SelendroidCapabilities(jsonSource);
+
+    String defaultApp = capa.getDefaultApp(supportedApps);
+    Assert.assertNull(defaultApp);
+  }
+
+}

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -217,8 +217,9 @@ public class SelendroidStandaloneDriver implements ServerDetails {
     while (retries >= 0) {
       try {
         SelendroidCapabilities desiredCapabilities = getSelendroidCapabilities(caps);
-
-        app = getAndroidApp(desiredCapabilities, desiredCapabilities.getAut());
+        String desiredAut = desiredCapabilities.getDefaultApp(appsStore.keySet());
+        app = getAndroidApp(desiredCapabilities, desiredAut);
+        log.info("'" + desiredAut + "' will be used as app under test.");
         device = deviceStore.findAndroidDevice(desiredCapabilities);
 
         // If we are using an emulator need to start it up


### PR DESCRIPTION
To enhance capability matching and to select the latest version of the app to test if the
app version is not provided by the users. This enhancement still retains the backward 
compatibility when users specified an AUT as "appName:appVersion".

Signed-off-by: Binh Vu bvu@paypal.com
