### PR TITLE
Trigger DOM event of type 'INPUT' after changing value of INPUT element

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Maven Artifacts
 
 You can find the current version in Maven central and the latest snapshot version here: [https://oss.sonatype.org/content/repositories/snapshots/](https://oss.sonatype.org/content/repositories/snapshots/)
 
+Building
+--------
+1. Install Cordova framework artifact to local .m2 repo by executing:
+```
+$ third-party/cordova-3.7.0/mvnInstall.sh
+```
+2. Run ```mvn clean compile package```
 
 License
 -----------

--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidWebElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidWebElement.java
@@ -335,7 +335,11 @@ public class AndroidWebElement implements AndroidElement {
     parameter.put(this);
     parameter.put(getText() + sb.toString());
 
-    driver.executeScript("arguments[0].value = arguments[1]", parameter, ke);
+    driver.executeScript("arguments[0].value = arguments[1];" +
+            "var inputEvent = document.createEvent('Event');" +
+            "inputEvent.initEvent('input', true, true);" +
+            "arguments[0].dispatchEvent(inputEvent);"
+            , parameter, ke);
   }
 
   @Override

--- a/selendroid-test-app/src/test/java/io/selendroid/support/BaseAndroidTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/support/BaseAndroidTest.java
@@ -13,6 +13,11 @@
  */
 package io.selendroid.support;
 
+import io.selendroid.client.SelendroidDriver;
+import io.selendroid.client.waiter.WaitingConditions;
+import io.selendroid.common.SelendroidCapabilities;
+import io.selendroid.standalone.SelendroidConfiguration;
+import io.selendroid.standalone.SelendroidLauncher;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -23,14 +28,8 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import io.selendroid.client.SelendroidDriver;
-import io.selendroid.client.waiter.WaitingConditions;
-import io.selendroid.common.SelendroidCapabilities;
-import io.selendroid.standalone.SelendroidConfiguration;
-import io.selendroid.standalone.SelendroidLauncher;
 import static io.selendroid.client.waiter.TestWaiter.waitFor;
 
 public class BaseAndroidTest {
@@ -49,12 +48,20 @@ public class BaseAndroidTest {
 
   @Before
   public void setup() throws Exception {
-    driver = new SelendroidDriver(getDefaultCapabilities());
-    driver().manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS);
+    createDriver(getDefaultCapabilities());
   }
 
   @After
   public void teardown() {
+    closeDriver();
+  }
+
+  protected void createDriver(final DesiredCapabilities caps) throws Exception {
+    driver = new SelendroidDriver(caps);
+    driver().manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS);
+  }
+
+  protected void closeDriver() {
     if (driver() != null) {
       driver().quit();
     }

--- a/selendroid-test-app/src/test/java/io/selendroid/webviewdrivertests/WebElementInteractionTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/webviewdrivertests/WebElementInteractionTest.java
@@ -13,12 +13,7 @@
  */
 package io.selendroid.webviewdrivertests;
 
-import static io.selendroid.client.waiter.TestWaiter.waitFor;
-import static io.selendroid.client.waiter.WaitingConditions.pageTitleToBe;
 import io.selendroid.support.BaseAndroidTest;
-
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -26,6 +21,13 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.selendroid.client.waiter.TestWaiter.waitFor;
+import static io.selendroid.client.waiter.WaitingConditions.pageTitleToBe;
 
 public class WebElementInteractionTest extends BaseAndroidTest {
   @Test
@@ -69,8 +71,7 @@ public class WebElementInteractionTest extends BaseAndroidTest {
 
   @Test
   public void shouldSendKeysAndClearAnElement() {
-    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
-    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+    givenWebViewWithFormPageLoaded();
 
     WebElement inputField = driver().findElement(By.id("email"));
     String text = "a.anyString@not.existent%.1.de";
@@ -81,9 +82,27 @@ public class WebElementInteractionTest extends BaseAndroidTest {
   }
 
   @Test
+  public void shouldTriggerInputEventWhenSendTextWithNativeKeyboard() throws Exception {
+    // ensure native keyboard is used
+    // according to io.selendroid.server.handler.SendKeysToElement.safeHandle()
+    Assert.assertTrue("Should use native keyboard", !hasNativeEventsDisabled());
+
+    givenWebViewWithFormPageLoaded();
+    whenSendingKeysToInputElement();
+    thenInputEventShouldBeTriggeredOnInputElement();
+  }
+
+  @Test
+  public void shouldTriggerInputEventWhenSendTextWithoutNativeKeyboard() throws Exception {
+    givenWebDriverWithNativeEventsDisabled();
+    givenWebViewWithFormPageLoaded();
+    whenSendingKeysToInputElement();
+    thenInputEventShouldBeTriggeredOnInputElement();
+  }
+
+  @Test
   public void shouldGetSelectedStateOfElement() {
-    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
-    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+    givenWebViewWithFormPageLoaded();
 
     WebElement element = driver().findElement(By.id("checky"));
     Assert.assertEquals(element.isSelected(), false);
@@ -97,8 +116,7 @@ public class WebElementInteractionTest extends BaseAndroidTest {
    */
   @Test
   public void shouldGetSizeOfElement() {
-    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
-    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+    givenWebViewWithFormPageLoaded();
 
     WebElement element = driver().findElement(By.id("checky"));
     Dimension size = element.getSize();
@@ -112,8 +130,7 @@ public class WebElementInteractionTest extends BaseAndroidTest {
    */
   @Test
   public void shouldGetLocationOfElement() {
-    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
-    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+    givenWebViewWithFormPageLoaded();
 
     WebElement element = driver().findElement(By.id("checky"));
     Point location = element.getLocation();
@@ -123,17 +140,15 @@ public class WebElementInteractionTest extends BaseAndroidTest {
 
   @Test
   public void shouldExecuteSimpleJavaScript() {
-    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
-    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+    givenWebViewWithFormPageLoaded();
 
-    String name = (String) ((JavascriptExecutor) driver()).executeScript("return document.title");
+    String name = (String) executeJavaScript("return document.title");
     Assert.assertEquals(name, "We Leave From Here");
   }
 
   @Test
   public void shouldGetDisplayedStateOfElement() {
-    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
-    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+    givenWebViewWithFormPageLoaded();
 
     WebElement element = driver().findElement(By.id("checky"));
     Assert.assertEquals(element.isDisplayed(), true);
@@ -141,8 +156,7 @@ public class WebElementInteractionTest extends BaseAndroidTest {
 
   @Test
   public void shouldGetEnbledStateOfElement() {
-    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
-    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+    givenWebViewWithFormPageLoaded();
 
     WebElement element = driver().findElement(By.id("checky"));
     Assert.assertEquals(element.isEnabled(), true);
@@ -158,7 +172,49 @@ public class WebElementInteractionTest extends BaseAndroidTest {
     inputField.sendKeys("Selendroid");
 
     inputField.submit();
-    String name = (String) ((JavascriptExecutor) driver()).executeScript("return document.title");
+    String name = (String) executeJavaScript("return document.title");
     Assert.assertEquals(name, "Hello: Selendroid");
+  }
+
+  private void givenWebDriverWithNativeEventsDisabled() throws Exception {
+    closeDriver();
+
+    final DesiredCapabilities caps = getDefaultCapabilities();
+    caps.setCapability(CapabilityType.HAS_NATIVE_EVENTS, false);
+
+    createDriver(caps);
+
+    // ensure native keyboard is NOT used
+    // according to io.selendroid.server.handler.SendKeysToElement.safeHandle()
+    Assert.assertTrue("Should NOT use native keyboard", hasNativeEventsDisabled());
+  }
+
+  protected void givenWebViewWithFormPageLoaded() {
+    openWebdriverTestPage(HtmlTestData.FORM_PAGE);
+    waitFor(pageTitleToBe(driver(), "We Leave From Here"), 10, TimeUnit.SECONDS);
+  }
+
+  protected Object executeJavaScript(String script) {
+    return ((JavascriptExecutor) driver()).executeScript(script);
+  }
+
+  private boolean hasNativeEventsDisabled() {
+    final Object capability = driver().getCapabilities().getCapability(CapabilityType.HAS_NATIVE_EVENTS);
+    return Boolean.FALSE.equals(capability);
+  }
+
+  private void whenSendingKeysToInputElement() {
+    executeJavaScript("window._input_event_triggered = false;   " +
+            "document.getElementById('email').addEventListener( " +
+            "  'input', function(event){                        " +
+            "    window._input_event_triggered = true;          " +
+            "  }                                                " +
+            ");                                                 ");
+    driver().findElement(By.id("email")).sendKeys("test");
+  }
+
+  private void thenInputEventShouldBeTriggeredOnInputElement() {
+    final Boolean isInputEventTriggered = (Boolean) executeJavaScript("return window._input_event_triggered;");
+    Assert.assertTrue("Input event must be triggered on sendKeys", isInputEventTriggered);
   }
 }

--- a/third-party/cordova-3.7.0/mvnInstall.sh
+++ b/third-party/cordova-3.7.0/mvnInstall.sh
@@ -1,4 +1,6 @@
-#!/bin/bash 
+#!/bin/bash
+pushd `dirname $0`
 mvn install:install-file -Dfile=classes.jar \
   -DgroupId=org.apache.cordova -DartifactId=cordova \
   -Dversion=3.7.0 -Dclassifier=android -Dpackaging=jar
+popd


### PR DESCRIPTION
When using native keyboard to send keys, then DOM event of type 'input' is triggered automatically by platform.

Opposite for AndroidWebElement, when setting value for INPUT element, then no DOM event of type 'input' is triggered.

This fix will trigger DOM event type 'input' after setting value of web element 'INPUT'.

AndroidWebElement is activated when Selenium session request has property nativeEvents set to false.