### PR TITLE
Grid auto re-register

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ * Copyright 2012-2015 eBay Software Foundation and selendroid committers.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,15 +15,12 @@ package io.selendroid.standalone;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-
 import io.selendroid.standalone.log.LogLevelConverter;
 import io.selendroid.standalone.log.LogLevelEnum;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -98,6 +95,10 @@ public class SelendroidConfiguration {
 
   @Parameter(names = "-maxInstances", description = "Maximum number of instances that a grid hub can use at a time.")
   private int maxInstances = 5;
+
+  @Parameter(names = "-registerCycle", description = "How often in ms the node will try to register itself again" +
+          ".Allow to restart the hub without having to restart the nodes. 0 to disable auto register. Default 0.")
+  private long registerCycle = 0;
 
   @Parameter(names = "-noWebviewApp",
              description = "If you don't want selendroid to auto-extract and have 'AndroidDriver' (webview only app) available.")
@@ -369,4 +370,13 @@ public class SelendroidConfiguration {
   public boolean isGrid() {
     return !StringUtils.isBlank(getRegistrationUrl()) && !StringUtils.isBlank(getServerHost());
   }
+
+  public long getRegisterCycle() {
+    return registerCycle;
+  }
+
+  public void setRegisterCycle(long registerCycle) {
+    this.registerCycle = registerCycle;
+  }
+
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/grid/SelfRegisteringRemote.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/grid/SelfRegisteringRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ * Copyright 2012-2015 eBay Software Foundation and selendroid committers.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,21 +13,25 @@
  */
 package io.selendroid.standalone.server.grid;
 
+import com.google.gson.Gson;
 import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.server.common.exceptions.SelendroidException;
 import io.selendroid.standalone.SelendroidConfiguration;
 import io.selendroid.standalone.server.model.SelendroidStandaloneDriver;
-import io.selendroid.standalone.server.util.HttpClientUtil;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openqa.selenium.remote.CapabilityType;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.Level;
@@ -41,42 +45,54 @@ public class SelfRegisteringRemote {
   public static final String ANDROIDDRIVER_APP = "io.selendroid.androiddriver";
   private SelendroidConfiguration config;
   private SelendroidStandaloneDriver driver;
+  private boolean isFirstTime = true;
+  private final URL hub;
 
   public SelfRegisteringRemote(SelendroidConfiguration config, SelendroidStandaloneDriver driver) {
     this.config = config;
     this.driver = driver;
+    this.hub = getGridHubUrl(config.getRegistrationUrl());
+  }
+
+  public void performRegistrationIfNotRegistered() {
+    try {
+      if (isFirstTime) {
+        performRegistration();
+        isFirstTime = false;
+      } else if (!isRegistered()) {
+        performRegistration();
+      }
+    } catch (Exception e) {
+      log.log(Level.SEVERE, "An error occurred while registering selendroid into grid hub.", e);
+    }
   }
 
   public void performRegistration() throws Exception {
-    String tmp = config.getRegistrationUrl();
+    String nodeConfigString = getNodeConfig().toString();
+    log.info("Registering Selendroid node with following config:\n" + nodeConfigString + "\n" +
+            "at Selenium Grid hub: " + hub.toExternalForm());
 
-    HttpClient client = HttpClientUtil.getHttpClient();
+    BasicHttpEntityEnclosingRequest request = new BasicHttpEntityEnclosingRequest("POST",
+            hub.toExternalForm());
+    request.setEntity(new StringEntity(nodeConfigString));
 
-    URL registration = new URL(tmp);
-    if (log.isLoggable(Level.INFO)) {
-      log.info("Registering selendroid node to Selenium Grid hub :" + registration);
-    }
-    BasicHttpEntityEnclosingRequest r =
-        new BasicHttpEntityEnclosingRequest("POST", registration.toExternalForm());
-    JSONObject nodeConfig = getNodeConfig();
-    String nodeConfigString = nodeConfig.toString();
-    if (log.isLoggable(Level.INFO)) {
-      log.info("Registering selendroid node with following config:\n" + nodeConfigString);
-    }
-    r.setEntity(new StringEntity(nodeConfigString));
+    HttpResponse response = getHttpClient().execute(getHttpHost(), request);
 
-    HttpHost host = new HttpHost(registration.getHost(), registration.getPort());
-    HttpResponse response = client.execute(host, r);
     if (response.getStatusLine().getStatusCode() != 200) {
-      throw new SelendroidException("Error sending the registration request.");
+      throw new SelendroidException("Error sending the registration request. Response from server: " +
+              response.getStatusLine().toString());
     }
+  }
+
+  // for testing purpose
+  protected HttpClient getHttpClient() {
+    return HttpClientBuilder.create().build();
   }
 
   /**
    * Get the node configuration and capabilities for Grid registration
    *
    * @return The configuration
-   * @throws JSONException On JSON errors.
    */
   private JSONObject getNodeConfig() {
     JSONObject res = new JSONObject();
@@ -88,27 +104,7 @@ public class SelfRegisteringRemote {
       for (int i = 0; i < devices.length(); i++) {
         JSONObject device = (JSONObject) devices.get(i);
         for (int x = 0; x < driver.getSupportedApps().length(); x++) {
-          JSONObject capa = new JSONObject();
-          capa.put(SelendroidCapabilities.SCREEN_SIZE,
-                  device.getString(SelendroidCapabilities.SCREEN_SIZE));
-          String version = device.getString(SelendroidCapabilities.PLATFORM_VERSION);
-          capa.put(SelendroidCapabilities.PLATFORM_VERSION, version);
-          capa.put(SelendroidCapabilities.EMULATOR, device.getString(SelendroidCapabilities.EMULATOR));
-          // For each device, register as "android" for WebView tests and also selendroid if an aut is specified
-          if (ANDROIDDRIVER_APP.equals(driver.getSupportedApps().getJSONObject(x).get(APP_BASE_PACKAGE))) {
-            //it's possible the user does not want to register the device as capable to recieve webview tests
-            if (!config.isNoWebViewApp()) {
-              capa.put(CapabilityType.BROWSER_NAME, "android");
-            }
-          } else {
-            capa.put(CapabilityType.BROWSER_NAME, "selendroid");
-            capa.put(SelendroidCapabilities.AUT, driver.getSupportedApps().getJSONObject(x).get(APP_ID));
-          }
-          capa.put(CapabilityType.PLATFORM, "ANDROID");
-          capa.put(SelendroidCapabilities.PLATFORM_NAME, "android");
-          capa.put(CapabilityType.VERSION, version);
-          capa.put("maxInstances", config.getMaxInstances());
-          caps.put(capa);
+          caps.put(getDeviceConfig(device, driver.getSupportedApps().getJSONObject(x)));
         }
       }
       res.put("capabilities", caps);
@@ -118,10 +114,33 @@ public class SelfRegisteringRemote {
     return res;
   }
 
+  private JSONObject getDeviceConfig(final JSONObject device, final JSONObject supportedApp) throws JSONException {
+    JSONObject capa = new JSONObject();
+    capa.put(SelendroidCapabilities.SCREEN_SIZE,
+            device.getString(SelendroidCapabilities.SCREEN_SIZE));
+    String version = device.getString(SelendroidCapabilities.PLATFORM_VERSION);
+    capa.put(SelendroidCapabilities.PLATFORM_VERSION, version);
+    capa.put(SelendroidCapabilities.EMULATOR, device.getString(SelendroidCapabilities.EMULATOR));
+    // For each device, register as "android" for WebView tests and also selendroid if an aut is specified
+    if (ANDROIDDRIVER_APP.equals(supportedApp.get(APP_BASE_PACKAGE))) {
+      //it's possible the user does not want to register the device as capable to recieve webview tests
+      if (!config.isNoWebViewApp()) {
+        capa.put(CapabilityType.BROWSER_NAME, "android");
+      }
+    } else {
+      capa.put(CapabilityType.BROWSER_NAME, "selendroid");
+      capa.put(SelendroidCapabilities.AUT, supportedApp.get(APP_ID));
+    }
+    capa.put(CapabilityType.PLATFORM, "ANDROID");
+    capa.put(SelendroidCapabilities.PLATFORM_NAME, "android");
+    capa.put(CapabilityType.VERSION, version);
+    capa.put("maxInstances", config.getMaxInstances());
+    return capa;
+  }
 
   /**
    * Extracts the configuration.
-   * 
+   *
    * @return The configuration
    * @throws JSONException On JSON errors.
    */
@@ -137,19 +156,12 @@ public class SelfRegisteringRemote {
       configuration.put("proxy", "org.openqa.grid.selenium.proxy.DefaultRemoteProxy");
     }
     configuration.put("role", "node");
-    configuration.put("registerCycle", 5000);
+    configuration.put("registerCycle", config.getRegisterCycle());
     configuration.put("maxSession", config.getMaxSession());
 
     // adding hub details
-    URL registrationUrl;
-    try {
-      registrationUrl = new URL(config.getRegistrationUrl());
-    } catch (MalformedURLException e) {
-      log.log(Level.SEVERE, "Grid hub url cannot be parsed", e);
-      throw new SelendroidException("Grid hub url cannot be parsed: " + e.getMessage());
-    }
-    configuration.put("hubHost", registrationUrl.getHost());
-    configuration.put("hubPort", registrationUrl.getPort());
+    configuration.put("hubHost", hub.getHost());
+    configuration.put("hubPort", hub.getPort());
 
     // adding driver details
     configuration.put("seleniumProtocol", "WebDriver");
@@ -157,4 +169,38 @@ public class SelfRegisteringRemote {
     configuration.put("remoteHost", "http://" + config.getServerHost() + ":" + config.getPort());
     return configuration;
   }
+
+  protected boolean isRegistered() {
+    try {
+      URL hubProxyApiUrl = new URL(hub.getProtocol(), hub.getHost(), hub.getPort(), "/grid/api/proxy");
+      HttpResponse response = getHttpClient().execute(getHttpHost(), new BasicHttpRequest("GET",
+              hubProxyApiUrl.toExternalForm() + "?id=http://" + config.getServerHost() + ":" + config.getPort()));
+
+      if (response.getStatusLine().getStatusCode() != 200) {
+        throw new RuntimeException("Hub is down or not responding. Response was: " + response.getStatusLine().toString());
+      }
+
+      GridResponse gridResponse = new Gson().fromJson(EntityUtils.toString(response.getEntity()), GridResponse.class);
+      return gridResponse.success;
+    } catch (IOException e) {
+      throw new SelendroidException("Hub is down or not responding.", e);
+    }
+  }
+
+  private HttpHost getHttpHost() {
+    return new HttpHost(hub.getHost(), hub.getPort(), hub.getProtocol());
+  }
+
+  private URL getGridHubUrl(String connectionString) {
+      try {
+        return new URL(connectionString);
+      } catch (MalformedURLException e) {
+        throw new SelendroidException("Grid hub connection string cannot be parsed into URL", e);
+      }
+  }
+
+  private class GridResponse {
+    private boolean success;
+  }
+
 }

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/server/grid/SelfRegisteringRemoteTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/server/grid/SelfRegisteringRemoteTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2012-2015 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.standalone.server.grid;
+
+import io.selendroid.server.common.exceptions.SelendroidException;
+import io.selendroid.standalone.SelendroidConfiguration;
+import io.selendroid.standalone.server.model.SelendroidStandaloneDriver;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SelfRegisteringRemoteTest {
+
+  private static final int HTTP_STATUS_CODE_OK = 200;
+  private static final int HTTP_STATUS_CODE_FORBIDDEN = 403;
+  @Mock private SelendroidConfiguration configuration;
+  @Mock private SelendroidStandaloneDriver driver;
+  @Mock private CloseableHttpClient client;
+  @Mock private CloseableHttpResponse response;
+  @Mock private StatusLine statusLine;
+  @Mock private HttpEntity responseEntity;
+
+  private SelfRegisteringRemote remote;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldRegisterAtGrid() throws Exception {
+    givenSupportedDevices();
+    givenRegistrationUrl();
+    givenResponseWithStatusCode(HTTP_STATUS_CODE_OK);
+    givenHttpClient();
+    givenSelfRegisteringRemote();
+    remote.performRegistration();
+  }
+
+  @Test(expected = SelendroidException.class)
+  public void shouldThrowExceptionWhenRegisterAtGridFails() throws Exception {
+    givenSupportedDevices();
+    givenRegistrationUrl();
+    givenResponseWithStatusCode(HTTP_STATUS_CODE_FORBIDDEN);
+    givenHttpClient();
+    givenSelfRegisteringRemote();
+    remote.performRegistration();
+  }
+
+  @Test
+  public void shouldRegisterAtGridFirstTime() throws Exception {
+    givenSupportedDevices();
+    givenRegistrationUrl();
+    givenResponseWithStatusCode(HTTP_STATUS_CODE_OK);
+    givenHttpClient();
+    givenSelfRegisteringRemote();
+    remote.performRegistrationIfNotRegistered();
+    verify(remote, times(1)).performRegistration();
+    verify(remote, times(0)).isRegistered();
+  }
+
+  @Test
+  public void shouldNotRegisterAtGridWhenAlreadyRegistered() throws Exception {
+    givenSupportedDevices();
+    givenRegistrationUrl();
+
+    when(statusLine.getStatusCode()).thenReturn(HTTP_STATUS_CODE_OK);
+    when(response.getStatusLine()).thenReturn(statusLine);
+
+    final byte[] bytes = "{ \"success\" : true }".getBytes(UTF_8);
+    when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(bytes), new ByteArrayInputStream(bytes));
+
+    when(response.getEntity()).thenReturn(responseEntity);
+
+    givenHttpClient();
+    givenSelfRegisteringRemote();
+
+    remote.performRegistrationIfNotRegistered(); // first registration - no check
+    remote.performRegistrationIfNotRegistered(); // check if registered - no reg
+    remote.performRegistrationIfNotRegistered(); // check if registered - no reg
+
+    verify(remote, times(1)).performRegistration();
+    verify(remote, times(2)).isRegistered();
+  }
+
+  @Test
+  public void shouldReRegisterAtGridWhenGridRestarted() throws Exception {
+    givenSupportedDevices();
+    givenRegistrationUrl();
+    givenResponseWithStatusCode(HTTP_STATUS_CODE_OK);
+
+    givenGridRestartedWhenCheckSecondTime();
+
+    givenHttpClient();
+    givenSelfRegisteringRemote();
+
+    remote.performRegistrationIfNotRegistered();    // first registration - no check
+    verify(remote, times(1)).performRegistration(); // call for reg
+    verify(remote, times(0)).isRegistered();        // no call for check
+
+    remote.performRegistrationIfNotRegistered();    // check if registered - no reg
+    verify(remote, times(1)).performRegistration(); // no more calls for reg
+    verify(remote, times(1)).isRegistered();        // call for check
+
+    // restarting grid
+    // isRegistered returns false for second check
+    remote.performRegistrationIfNotRegistered();    // check if registered and reg!
+    verify(remote, times(2)).performRegistration(); // second call for reg
+    verify(remote, times(2)).isRegistered();        // second call for check
+  }
+
+  protected void givenGridRestartedWhenCheckSecondTime() throws IOException {
+    final byte[] bytesSuccess = "{ \"success\" : true }".getBytes(UTF_8); // first isRegistered check
+    final byte[] bytesFail = "{ \"success\" : false }".getBytes(UTF_8);   // second isRegistered check
+    when(responseEntity.getContent()).thenReturn(
+            new ByteArrayInputStream(bytesSuccess),
+            new ByteArrayInputStream(bytesFail));
+    when(response.getEntity()).thenReturn(responseEntity);
+  }
+
+  @Test
+  public void shouldThrowMalformedURLException() {
+    try {
+      givenSelfRegisteringRemote();
+    } catch (Exception e) {
+      assertThat("Must be instance of " + SelendroidException.class.getName(), e,
+              instanceOf(SelendroidException.class));
+      assertThat("Cause must be instance of " + MalformedURLException.class.getName(), e.getCause(),
+              instanceOf(MalformedURLException.class));
+    }
+  }
+
+  private void givenHttpClient() throws IOException {
+    when(client.execute(any(HttpHost.class), any(HttpRequest.class))).thenReturn(response);
+  }
+
+  private void givenResponseWithStatusCode(int code) {
+    when(statusLine.getStatusCode()).thenReturn(code);
+    when(response.getStatusLine()).thenReturn(statusLine);
+  }
+
+  private void givenSupportedDevices() {
+    JSONArray ja = new JSONArray();
+    when(driver.getSupportedDevices()).thenReturn(ja);
+  }
+
+  private void givenRegistrationUrl() {
+    when(configuration.getRegistrationUrl()).thenReturn("http://1.2.3.4:4444/grid/register");
+  }
+
+  private void givenSelfRegisteringRemote() {
+    remote = Mockito.spy(new SelfRegisteringRemoteWithMocks(configuration, driver));
+  }
+
+  private class SelfRegisteringRemoteWithMocks extends SelfRegisteringRemote {
+    public SelfRegisteringRemoteWithMocks(SelendroidConfiguration config, SelendroidStandaloneDriver driver) {
+      super(config, driver);
+    }
+
+    @Override
+    protected HttpClient getHttpClient() {
+      return client;
+    }
+  }
+}


### PR DESCRIPTION
If a grid hub was restarted, then SelendroidStandaloneServer will re-register itself again.

Commit details:
  a task created for self registration - first check grid if the node already registered, and re-register if not.
  then the task is scheduled for execution (recurrence is configured via -registerCycle argument) 

A nice feature that I found useful when having a farm of selendroid-servers. :-)