### PR TITLE
Adding "deviceType" as a configurable parameter option.

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
@@ -47,6 +47,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public static final String SCREEN_SIZE = "screenSize";
   public static final String PRE_SESSION_ADB_COMMANDS = "preSessionAdbCommands";
   public static final String SERIAL = "serial";
+  public static final String MODEL = "model";
 
   public static final String PLATFORM_VERSION = "platformVersion";
   public static final String PLATFORM_NAME = "platformName";
@@ -84,7 +85,11 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public String getAut() {
     return (String) getRawCapabilities().get(AUT);
   }
-  
+
+  public String getModel() {
+    return (String) getRawCapabilities().get(MODEL);
+  }
+
   public String getLaunchActivity() {
 	return (String) getRawCapabilities().get(LAUNCH_ACTIVITY);
   }
@@ -94,15 +99,15 @@ public class SelendroidCapabilities extends DesiredCapabilities {
         || getRawCapabilities().get(EMULATOR).equals(JSONObject.NULL)) return null;
     return (Boolean) getRawCapabilities().get(EMULATOR);
   }
-  
+
   public String getPlatformName() {
     return (String) getRawCapabilities().get(PLATFORM_NAME);
   }
-  
+
   public String getAutomationName() {
     return (String) getRawCapabilities().get(AUTOMATION_NAME);
   }
-  
+
   public String getLocale() {
     return (String) getRawCapabilities().get(LOCALE);
   }
@@ -133,6 +138,10 @@ public class SelendroidCapabilities extends DesiredCapabilities {
 
   public void setSerial(String serial) {
     setCapability(SERIAL, serial);
+  }
+
+  public void setModel(String model) {
+    setCapability(MODEL, model);
   }
 
   public void setPlatformVersion(DeviceTargetPlatform androidTarget) {

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
@@ -21,6 +21,8 @@ import io.selendroid.standalone.exceptions.AndroidSdkException;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.logging.LogEntry;
 
+import com.google.common.base.Predicates;
+
 import java.util.List;
 import java.util.Locale;
 
@@ -90,4 +92,6 @@ public interface AndroidDevice {
    * Returns the output of running 'adb shell ps', filtering out system processes.
    */
   public String listRunningThirdPartyProcesses();
+
+  public String getModel();
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidEmulator.java
@@ -57,4 +57,6 @@ public interface AndroidEmulator {
   public void unlockEmulatorScreen() throws AndroidDeviceException;
 
   public void setWasStartedBySelendroid(boolean wasStartedBySelendroid);
+
+  public String getModel();
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -63,6 +63,7 @@ public abstract class AbstractDevice implements AndroidDevice {
   private static final Logger log = Logger.getLogger(AbstractDevice.class.getName());
   public static final String WD_STATUS_ENDPOINT = "http://localhost:8080/wd/hub/status";
   protected String serial = null;
+  protected String model = null;
   protected Integer port = null;
   protected IDevice device;
   private ByteArrayOutputStream logoutput;
@@ -600,5 +601,9 @@ public abstract class AbstractDevice implements AndroidDevice {
   @Override
   public int hashCode() {
     return device.hashCode();
+  }
+
+  public String getModel() {
+    return model;
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
@@ -71,8 +71,9 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   }
 
   public DefaultAndroidEmulator(String avdName, String abi, Dimension screenSize, String target,
-                                File avdFilePath) {
+                                String model, File avdFilePath) {
     this.avdName = avdName;
+    this.model = model;
     this.screenSize = screenSize;
     this.avdRootFolder = avdFilePath;
     this.targetPlatform = DeviceTargetPlatform.fromInt(target);
@@ -134,8 +135,9 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
         Dimension screenSize = getScreenSizeFromSkin(extractValue("Skin: (.*?)$", element));
         String target = extractValue("\\(API level (.*?)\\)", element);
         File avdFilePath = new File(extractValue("Path: (.*?)$", element));
+        String model = extractValue("Device: (.*?)$", element);
         DefaultAndroidEmulator emulator =
-            new DefaultAndroidEmulator(avdName, abi, screenSize, target, avdFilePath);
+            new DefaultAndroidEmulator(avdName, abi, screenSize, target, model, avdFilePath);
         if (startedDevices.containsKey(avdName)) {
           emulator.setSerial(startedDevices.get(avdName));
         }
@@ -208,7 +210,7 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   @Override
   public String toString() {
     return "AndroidEmulator [screenSize=" + screenSize + ", targetPlatform=" + targetPlatform
-        + ", serial=" + serial + ", avdName=" + avdName + "]";
+        + ", serial=" + serial + ", avdName=" + avdName + ", model=" + model + "]";
   }
 
   public void setSerial(int port) {
@@ -493,4 +495,5 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   public void setWasStartedBySelendroid(boolean wasStartedBySelendroid) {
     this.wasStartedBySelendroid = wasStartedBySelendroid;
   }
+
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
@@ -95,5 +95,4 @@ public class DefaultHardwareDevice extends AbstractDevice {
 	  return serial;
   }
 
-
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/DeviceStore.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/DeviceStore.java
@@ -334,7 +334,8 @@ public class DeviceStore {
             candidate.screenSizeMatches(capabilities.getScreenSize()),
             capabilities.getEmulator() == null ? true : capabilities.getEmulator() ?
                 candidate instanceof DefaultAndroidEmulator : candidate instanceof DefaultHardwareDevice,
-            StringUtils.isNotBlank(capabilities.getSerial()) ? capabilities.getSerial().equals(candidate.getSerial()) : true
+            StringUtils.isNotBlank(capabilities.getSerial()) ? capabilities.getSerial().equals(candidate.getSerial()) : true,
+            StringUtils.isNotBlank(capabilities.getModel()) ? candidate.getModel().contains(capabilities.getModel()) : true
         );
 
         return Iterables.all(booleanExpressions, Predicates.equalTo(true));

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulatorTests.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulatorTests.java
@@ -35,7 +35,7 @@ public class DefaultAndroidEmulatorTests {
   @Test
   public void testShouldBeAbleToStartEmulator() throws Exception {
     AndroidEmulator emulator =
-        new DefaultAndroidEmulator("l10n", "X86", new Dimension(320, 480), "16", new File(
+        new DefaultAndroidEmulator("l10n", "X86", new Dimension(320, 480), "16", "Nexus 5", new File(
             FileUtils.getUserDirectory(), ".android" + File.separator + "avd" + File.separator
                 + "l10n.avd"));
 

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreFixture.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreFixture.java
@@ -17,10 +17,12 @@ import com.android.ddmlib.IDevice;
 
 import java.util.Map;
 
+import static io.selendroid.standalone.server.model.DeviceStoreFixture.withDefaultCapabilities;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.common.device.DeviceTargetPlatform;
+import io.selendroid.standalone.android.AndroidDevice;
 import io.selendroid.standalone.android.DeviceManager;
 import io.selendroid.standalone.android.impl.DefaultAndroidEmulator;
 import io.selendroid.standalone.android.impl.DefaultHardwareDevice;
@@ -46,11 +48,11 @@ public class DeviceStoreFixture {
     return new FakeHardwareDevice(device, prop);
   }
 
-
   protected static DefaultAndroidEmulator anEmulator(String name, DeviceTargetPlatform platform,
       boolean isEmulatorStarted) throws AndroidDeviceException {
     DefaultAndroidEmulator emulator = mock(DefaultAndroidEmulator.class);
     when(emulator.getAvdName()).thenReturn(name);
+    when(emulator.getModel()).thenReturn("Nexus 5");
     when(emulator.getTargetPlatform()).thenReturn(platform);
     when(emulator.isEmulatorStarted()).thenReturn(isEmulatorStarted);
     when(emulator.isDeviceReady()).thenReturn(false);
@@ -58,14 +60,30 @@ public class DeviceStoreFixture {
 
     return emulator;
   }
-  
+
   protected static SelendroidCapabilities withDefaultCapabilities() {
     SelendroidCapabilities capabilities = new SelendroidCapabilities();
     capabilities.setPlatformVersion(DeviceTargetPlatform.ANDROID16);
     capabilities.setScreenSize("320x480");
     return capabilities;
   }
-  
+
+  protected static SelendroidCapabilities withModelCapabilities() {
+    SelendroidCapabilities capabilities = new SelendroidCapabilities();
+    capabilities.setPlatformVersion(DeviceTargetPlatform.ANDROID16);
+    capabilities.setModel("Nexus 5");
+    capabilities.setScreenSize("320x480");
+    return capabilities;
+  }
+
+  protected static SelendroidCapabilities withWrongModelCapabilities() {
+    SelendroidCapabilities capabilities = new SelendroidCapabilities();
+    capabilities.setPlatformVersion(DeviceTargetPlatform.ANDROID16);
+    capabilities.setModel("Nexus 7");
+    capabilities.setScreenSize("320x480");
+    return capabilities;
+  }
+
   protected static DeviceManager anDeviceManager() throws AndroidDeviceException {
     DeviceManager finder = mock(DeviceManager.class);
     when(finder.getVirtualDevice("emulator-5554")).thenReturn(null);

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreTest.java
@@ -17,6 +17,8 @@ import static io.selendroid.standalone.server.model.DeviceStoreFixture.anDevice;
 import static io.selendroid.standalone.server.model.DeviceStoreFixture.anDeviceManager;
 import static io.selendroid.standalone.server.model.DeviceStoreFixture.anEmulator;
 import static io.selendroid.standalone.server.model.DeviceStoreFixture.withDefaultCapabilities;
+import static io.selendroid.standalone.server.model.DeviceStoreFixture.withModelCapabilities;
+import static io.selendroid.standalone.server.model.DeviceStoreFixture.withWrongModelCapabilities;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -494,5 +496,64 @@ public class DeviceStoreTest {
     assertThat(device, equalTo((AndroidDevice) deEmulator16));
     // the device is in use when found
     assertThat(deviceStore.getDevicesInUse(), contains((AndroidDevice) deEmulator16));
+  }
+
+  @Test
+  public void shouldFindAnEmulatorWithSpecifiedModel() throws Exception {
+    // adding Nexus 5 to device store
+    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, true);
+    DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
+    deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {emulator}));
+
+    // find by Capabilities
+    AndroidDevice foundEmulator = deviceStore.findAndroidDevice(withModelCapabilities());
+    // the right device is found
+    assertThat(foundEmulator, equalTo((AndroidDevice) emulator));
+  }
+
+  @Test
+  public void shouldFindARealDeviceWithSpecifiedModel() throws Exception {
+    // adding Nexus 5 to device store
+    DefaultHardwareDevice device = anDevice("Nexus 5", DeviceTargetPlatform.ANDROID16);
+    DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
+    deviceStore.addDevice(device);
+
+ // find by Capabilities
+    AndroidDevice foundDevice = deviceStore.findAndroidDevice(withModelCapabilities());
+ // the right device is found
+    assertThat(foundDevice, equalTo((AndroidDevice) device));
+  }
+
+  @Test
+  public void shouldNotFindAnEmulatorWithWrongModel() throws Exception {
+    // adding Nexus 5 to device store
+    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, true);
+    DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
+    deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {emulator}));
+
+    try {
+      deviceStore.findAndroidDevice(withWrongModelCapabilities());
+      Assert.fail();
+    } catch (DeviceStoreException e) {
+      assertThat(
+          e.getMessage(),
+          equalTo("No devices are found. This can happen if the devices are in use or no device screen matches the required capabilities."));
+    }
+  }
+  @Test
+  public void shouldNotFindARealDeviceWithWrongModel() throws Exception {
+    // adding Nexus 5 to device store
+    AndroidDevice device = anDevice("Nexus 5", DeviceTargetPlatform.ANDROID16);
+    DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
+    deviceStore.addDevice(device);
+
+    try {
+      deviceStore.findAndroidDevice(withWrongModelCapabilities());
+      Assert.fail();
+    } catch (DeviceStoreException e) {
+      assertThat(
+          e.getMessage(),
+          equalTo("No devices are found. This can happen if the devices are in use or no device screen matches the required capabilities."));
+    }
   }
 }


### PR DESCRIPTION
So users can select a specific device together with the SDK version
for their tests. Previously, users can only specify the SDK version
for the tests and if there are several devices with the same SDK
version, selendroid will automatically select the first device to
carry out the test, which may not be the intended device for the
test.

This parameter can be ignored if the users are not desired to select
a specific device for the test.

Signed-off-by: Binh Vu <bvu@paypal.com>