### PR TITLE
Cleaner exception when instrumentation fails

### DIFF
--- a/selendroid-common/src/test/java/io/selendroid/common/SelendroidCapabilitiesTest.java
+++ b/selendroid-common/src/test/java/io/selendroid/common/SelendroidCapabilitiesTest.java
@@ -13,7 +13,6 @@
  */
 package io.selendroid.common;
 
-import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.common.device.DeviceTargetPlatform;
 
 import org.json.JSONObject;
@@ -23,7 +22,7 @@ import org.junit.Test;
 public class SelendroidCapabilitiesTest {
 
   @Test
-  public void testInstanstiateFromJSON() throws Exception {
+  public void testInstantiateFromJSON() throws Exception {
     JSONObject jsonSource = new JSONObject();
     jsonSource.put("browserName", "selendroid");
     jsonSource.put("platformVersion", DeviceTargetPlatform.ANDROID16.getApi());

--- a/selendroid-server-common/src/test/java/io/selendroid/server/common/SelendroidResponseTest.java
+++ b/selendroid-server-common/src/test/java/io/selendroid/server/common/SelendroidResponseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.common;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SelendroidResponseTest {
+
+  @Test
+  public void testRenderKnownError() throws JSONException {
+    SelendroidResponse response =
+        new SelendroidResponse("my-session", StatusCode.INVALID_SELECTOR, new RuntimeException("Invalid selector"));
+    JSONObject rendered = new JSONObject(response.render());
+
+    assertEquals("my-session", rendered.getString("sessionId"));
+    assertEquals(StatusCode.INVALID_SELECTOR.getCode(), rendered.getLong("status"));
+    assertEquals("java.lang.RuntimeException", rendered.getJSONObject("value").getString("class"));
+    assertEquals("Invalid selector", rendered.getJSONObject("value").getString("message"));
+  }
+
+  @Test
+  public void testRenderUnknownError() throws JSONException {
+    SelendroidResponse response =
+        new SelendroidResponse("my-session", StatusCode.UNKNOWN_ERROR, new RuntimeException());
+    JSONObject rendered = new JSONObject(response.render());
+
+    assertEquals("my-session", rendered.getString("sessionId"));
+    assertEquals(StatusCode.UNKNOWN_ERROR.getCode(), rendered.getLong("status"));
+    assertEquals("java.lang.RuntimeException", rendered.getJSONObject("value").getString("class"));
+    Assert.assertTrue(rendered.getJSONObject("value").getString("message").startsWith(
+        "java.lang.RuntimeException\n\tat io.selendroid.server.common.SelendroidResponseTest"));
+  }
+
+  @Test
+  public void testRenderCatchAllError() throws JSONException {
+    SelendroidResponse response = SelendroidResponse.forCatchAllError("my-session", new RuntimeException());
+    JSONObject rendered = new JSONObject(response.render());
+
+    assertEquals("my-session", rendered.getString("sessionId"));
+    assertEquals(StatusCode.UNKNOWN_ERROR.getCode(), rendered.getLong("status"));
+    assertEquals("java.lang.RuntimeException", rendered.getJSONObject("value").getString("class"));
+    Assert.assertTrue(rendered.getJSONObject("value").getString("message").startsWith(
+        "CATCH_ALL: java.lang.RuntimeException\n\tat io.selendroid.server.common.SelendroidResponseTest"));
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/handler/SafeRequestHandler.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/SafeRequestHandler.java
@@ -109,12 +109,12 @@ public abstract class SafeRequestHandler extends BaseRequestHandler {
       return new SelendroidResponse(getSessionId(request), StatusCode.UNKNOWN_COMMAND, e);
     } catch (Exception e) {
       SelendroidLogger.error("Exception while handling action in: " + this.getClass().getName(), e);
-      return SelendroidResponse.forCatchAllError(getSessionId(request), StatusCode.UNKNOWN_ERROR, e);
+      return SelendroidResponse.forCatchAllError(getSessionId(request), e);
     } catch (Error e) {
       // Catching Errors seems like a bad idea in general but if we don't catch this, Netty will catch it anyway.
       // The advantage of catching it here is that we can propagate the Error to clients.
       SelendroidLogger.error("Fatal error while handling action in: " + this.getClass().getName(), e);
-      return SelendroidResponse.forCatchAllError(getSessionId(request), StatusCode.UNKNOWN_ERROR, e);
+      return SelendroidResponse.forCatchAllError(getSessionId(request), e);
     }
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -237,8 +237,7 @@ public abstract class AbstractDevice implements AndroidDevice {
 
     List<String> argList = Lists.newArrayList(
         "-e", "main_activity", aut.getMainActivity(),
-        "-e", "server_port", Integer.toString(port)
-        );
+        "-e", "server_port", Integer.toString(port));
     if (capabilities.getSelendroidExtensions() != null) {
       argList.addAll(Lists.newArrayList("-e", "load_extensions", "true"));
       if (capabilities.getBootstrapClassNames() != null) {
@@ -253,19 +252,25 @@ public abstract class AbstractDevice implements AndroidDevice {
 
     String result = executeCommandQuietly(command);
     if (result.contains("FAILED")) {
-      String detailedResult;
+      String genericMessage = "Could not start the app under test using instrumentation.";
+      String detailedMessage;
       try {
         // Try again, waiting for instrumentation to finish. This way we'll get more error output.
         String[] instrumentCmd =
             ObjectArrays.concat(new String[]{"shell", "am", "instrument", "-w"}, args, String.class);
-        CommandLine getErrorDetailCommand = adbCommand(instrumentCmd);
-        detailedResult = executeCommandQuietly(getErrorDetailCommand);
+        CommandLine getDetailedErrorCommand = adbCommand(instrumentCmd);
+        String detailedResult = executeCommandQuietly(getDetailedErrorCommand);
+        if (detailedResult.contains("package")) {
+          detailedMessage =
+              genericMessage + " Is the correct app under test installed? Read the details below:\n" + detailedResult;
+        } else {
+          detailedMessage = genericMessage + " Read the details below:\n" + detailedResult;
+        }
       } catch (Exception e) {
-        detailedResult = "Could not run get detailed result: " +
-            e.getMessage() + "\n" + Throwables.getStackTraceAsString(e);
+        // Can't get detailed results
+        throw new SelendroidException(genericMessage, e);
       }
-      throw new SelendroidException("Error occurred while starting selendroid-server on the device",
-          new Throwable(result + "\nDetails:\n" + detailedResult));
+      throw new SelendroidException(detailedMessage);
     }
 
     forwardSelendroidPort(port);
@@ -303,7 +308,7 @@ public abstract class AbstractDevice implements AndroidDevice {
     String url = WD_STATUS_ENDPOINT.replace("8080", String.valueOf(port));
     log.info("Using url: " + url);
     HttpRequestBase request = new HttpGet(url);
-    HttpResponse response = null;
+    HttpResponse response;
     try {
       response = httpClient.execute(request);
     } catch (Exception e) {


### PR DESCRIPTION
We not only return Selendroid stack traces to clients in case of an `UNKNOWN_ERROR`. The reason is documented in `SelendroidResponse`:

```
// Also include the Selendroid stack trace. Only do this in case of unknown errors for easier debugging.
// In case of an expected error the stack trace is unnecessary and users often find it confusing.
```

The error message returned to client is:

Before:

- status code: `SESSION_NOT_CREATED_EXCEPTION`
- message:

```
io.selendroid.server.common.exceptions.SelendroidException: Error occurred while starting selendroid-server on the device
	at io.selendroid.standalone.android.impl.AbstractDevice.startSelendroid(AbstractDevice.java:267)
	at io.selendroid.standalone.server.model.SelendroidStandaloneDriver.createNewTestSession(SelendroidStandaloneDriver.java:264)
	at io.selendroid.standalone.server.model.SelendroidStandaloneDriver.createNewTestSession(SelendroidStandaloneDriver.java:210)
	at io.selendroid.standalone.server.handler.CreateSessionHandler.handleRequest(CreateSessionHandler.java:40)
	at io.selendroid.standalone.server.BaseSelendroidStandaloneHandler.handle(BaseSelendroidStandaloneHandler.java:45)
	at io.selendroid.standalone.server.SelendroidServlet.handleRequest(SelendroidServlet.java:131)
	at io.selendroid.server.common.BaseServlet.handleHttpRequest(BaseServlet.java:67)
	at io.selendroid.server.common.http.ServerHandler.channelRead(ServerHandler.java:53)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.handler.traffic.AbstractTrafficShapingHandler.channelRead(AbstractTrafficShapingHandler.java:223)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:153)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:148)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:132)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:485)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:452)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:346)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Throwable: android.util.AndroidException: INSTRUMENTATION_FAILED: io.selendroid.com.example.myapp/io.selendroid.server.ServerInstrumentation
	at com.android.commands.am.Am.runInstrument(Am.java:616)
	at com.android.commands.am.Am.run(Am.java:118)
	at com.android.commands.am.Am.main(Am.java:81)
	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:237)
	at dalvik.system.NativeStart.main(Native Method)
Details:
INSTRUMENTATION_STATUS: id=ActivityManagerServiceandroid.util.AndroidException: INSTRUMENTATION_FAILED: io.selendroid.com.example.myapp/io.selendroid.server.ServerInstrumentation

INSTRUMENTATION_STATUS: Error=Unable to find instrumentation target package: com.example.myapp
INSTRUMENTATION_STATUS_CODE: -1
	at com.android.commands.am.Am.runInstrument(Am.java:616)
	at com.android.commands.am.Am.run(Am.java:118)
	at com.android.commands.am.Am.main(Am.java:81)
	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:237)
	at dalvik.system.NativeStart.main(Native Method)
	... 27 more
```

---

After:

- status code: `SESSION_NOT_CREATED_EXCEPTION`
- message:

```
io.selendroid.server.common.exceptions.SelendroidException: Could not start the app under test using instrumentation. Is the correct app under test installed? Read the details below:
INSTRUMENTATION_STATUS: id=ActivityManagerServiceandroid.util.AndroidException: INSTRUMENTATION_FAILED: io.selendroid.com.example.myapp/io.selendroid.server.ServerInstrumentation

INSTRUMENTATION_STATUS: Error=Unable to find instrumentation target package: com.example.myapp
INSTRUMENTATION_STATUS_CODE: -1
	at com.android.commands.am.Am.runInstrument(Am.java:616)
	at com.android.commands.am.Am.run(Am.java:118)
	at com.android.commands.am.Am.main(Am.java:81)
	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:237)
	at dalvik.system.NativeStart.main(Native Method)
	at io.selendroid.standalone.android.impl.AbstractDevice.startSelendroid(AbstractDevice.java:269)
	... 26 more
```