### PR TITLE
Don't log exception when waiting for the Selendroid server to start

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -307,14 +307,13 @@ public abstract class AbstractDevice implements AndroidDevice {
   public boolean isSelendroidRunning() {
     HttpClient httpClient = HttpClientBuilder.create().build();
     String url = WD_STATUS_ENDPOINT.replace("8080", String.valueOf(port));
-    log.info("Using url: " + url);
+    log.info("Checking if the Selendroid server is running: " + url);
     HttpRequestBase request = new HttpGet(url);
     HttpResponse response;
     try {
       response = httpClient.execute(request);
     } catch (Exception e) {
-      log.log(Level.INFO, "Error checking if selendroid-server has started.", e);
-      log.info("Assuming server has not started");
+      log.info("Can't connect to Selendroid server, assuming it is not running.");
       return false;
     }
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -325,6 +325,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
   private void waitForServerStart(AndroidDevice device) {
     long startTimeout = serverConfiguration.getServerStartTimeout();
     long timeoutEnd = System.currentTimeMillis() + startTimeout;
+    log.info("Waiting for the Selendroid server to start.");
     while (!device.isSelendroidRunning()) {
       if (timeoutEnd >= System.currentTimeMillis()) {
         try {
@@ -341,6 +342,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
                 + startTimeout / 1000 + "sec:");
       }
     }
+    log.info("Selendroid server has started.");
   }
 
   private void pushExtensionsToDevice(AndroidDevice device, String extensionFile) {


### PR DESCRIPTION
We log an uninteresting exception every two seconds when waiting for the Selendroid server to come up on the device. This makes the log harder to read:

```
INFO: Error checking if selendroid-server has started.
java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:196)
	at java.net.SocketInputStream.read(SocketInputStream.java:122)
	at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:136)
	at org.apache.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:152)
	at org.apache.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:270)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:140)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:57)
	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:260)
	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:161)
	at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:153)
	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:271)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:123)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:254)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:195)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:86)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:108)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:106)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:57)
	at io.selendroid.standalone.android.impl.AbstractDevice.isSelendroidRunning(AbstractDevice.java:308)
	at io.selendroid.standalone.server.model.SelendroidStandaloneDriver.waitForServerStart(SelendroidStandaloneDriver.java:328)
	at io.selendroid.standalone.server.model.SelendroidStandaloneDriver.createNewTestSession(SelendroidStandaloneDriver.java:265)
	at io.selendroid.standalone.server.model.SelendroidStandaloneDriver.createNewTestSession(SelendroidStandaloneDriver.java:210)
	at io.selendroid.standalone.server.handler.CreateSessionHandler.handleRequest(CreateSessionHandler.java:40)
	at io.selendroid.standalone.server.BaseSelendroidStandaloneHandler.handle(BaseSelendroidStandaloneHandler.java:45)
	at io.selendroid.standalone.server.SelendroidServlet.handleRequest(SelendroidServlet.java:131)
	at io.selendroid.server.common.BaseServlet.handleHttpRequest(BaseServlet.java:67)
	at io.selendroid.server.common.http.ServerHandler.channelRead(ServerHandler.java:53)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.handler.traffic.AbstractTrafficShapingHandler.channelRead(AbstractTrafficShapingHandler.java:223)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:153)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:148)
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:338)
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:324)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:132)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:485)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:452)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:346)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101)
	at java.lang.Thread.run(Thread.java:744)
```