### PR TITLE
Adding "apiType" as an option in selendroid capabilities.

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
@@ -48,6 +48,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public static final String PRE_SESSION_ADB_COMMANDS = "preSessionAdbCommands";
   public static final String SERIAL = "serial";
   public static final String MODEL = "model";
+  public static final String API_TYPE = "apiType";
 
   public static final String PLATFORM_VERSION = "platformVersion";
   public static final String PLATFORM_NAME = "platformName";
@@ -120,6 +121,10 @@ public class SelendroidCapabilities extends DesiredCapabilities {
     return (String) getRawCapabilities().get(SCREEN_SIZE);
   }
 
+  public String getAPIType() {
+    return (String) getRawCapabilities().get(API_TYPE);
+  }
+
   /**
    * Full path of the dex file (on the host machine) containing Selendroid extensions to be loaded at run time
    * Example: /home/user/extension.dex
@@ -142,6 +147,10 @@ public class SelendroidCapabilities extends DesiredCapabilities {
 
   public void setModel(String model) {
     setCapability(MODEL, model);
+  }
+
+  public void setAPIType(String apiType) {
+    setCapability(API_TYPE, apiType);
   }
 
   public void setPlatformVersion(DeviceTargetPlatform androidTarget) {

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
@@ -94,4 +94,6 @@ public interface AndroidDevice {
   public String listRunningThirdPartyProcesses();
 
   public String getModel();
+
+  public String getAPIType();
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidEmulator.java
@@ -59,4 +59,6 @@ public interface AndroidEmulator {
   public void setWasStartedBySelendroid(boolean wasStartedBySelendroid);
 
   public String getModel();
+
+  public String getAPIType();
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
@@ -64,6 +64,7 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   private String avdName;
   private File avdRootFolder;
   private Locale locale = null;
+  private String apiType = null;
   private boolean wasStartedBySelendroid;
 
   protected DefaultAndroidEmulator() {
@@ -71,13 +72,14 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   }
 
   public DefaultAndroidEmulator(String avdName, String abi, Dimension screenSize, String target,
-                                String model, File avdFilePath) {
+                                String model, File avdFilePath, String apiType) {
     this.avdName = avdName;
     this.model = model;
     this.screenSize = screenSize;
     this.avdRootFolder = avdFilePath;
     this.targetPlatform = DeviceTargetPlatform.fromInt(target);
     this.wasStartedBySelendroid = !isEmulatorStarted();
+    this.apiType = apiType;
   }
 
   public File getAvdRootFolder() {
@@ -136,8 +138,9 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
         String target = extractValue("\\(API level (.*?)\\)", element);
         File avdFilePath = new File(extractValue("Path: (.*?)$", element));
         String model = extractValue("Device: (.*?)$", element);
+        String apiType = extractValue("Target: (.*?) ", element);
         DefaultAndroidEmulator emulator =
-            new DefaultAndroidEmulator(avdName, abi, screenSize, target, model, avdFilePath);
+            new DefaultAndroidEmulator(avdName, abi, screenSize, target, model, avdFilePath, apiType);
         if (startedDevices.containsKey(avdName)) {
           emulator.setSerial(startedDevices.get(avdName));
         }
@@ -210,7 +213,7 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   @Override
   public String toString() {
     return "AndroidEmulator [screenSize=" + screenSize + ", targetPlatform=" + targetPlatform
-        + ", serial=" + serial + ", avdName=" + avdName + ", model=" + model + "]";
+        + ", serial=" + serial + ", avdName=" + avdName + ", model=" + model + ", apiType=" + apiType + "]";
   }
 
   public void setSerial(int port) {
@@ -496,4 +499,8 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
     this.wasStartedBySelendroid = wasStartedBySelendroid;
   }
 
+  @Override
+  public String getAPIType() {
+    return apiType;
+  }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
@@ -95,4 +95,8 @@ public class DefaultHardwareDevice extends AbstractDevice {
 	  return serial;
   }
 
+  @Override
+  public String getAPIType() {
+    return null;
+  }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/DeviceStore.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/DeviceStore.java
@@ -335,7 +335,9 @@ public class DeviceStore {
             capabilities.getEmulator() == null ? true : capabilities.getEmulator() ?
                 candidate instanceof DefaultAndroidEmulator : candidate instanceof DefaultHardwareDevice,
             StringUtils.isNotBlank(capabilities.getSerial()) ? capabilities.getSerial().equals(candidate.getSerial()) : true,
-            StringUtils.isNotBlank(capabilities.getModel()) ? candidate.getModel().contains(capabilities.getModel()) : true
+            StringUtils.isNotBlank(capabilities.getModel()) ? candidate.getModel().contains(capabilities.getModel()) : true,
+            StringUtils.isNotBlank(capabilities.getAPIType()) ? 
+                candidate.getAPIType() != null && candidate.getAPIType().contains(capabilities.getAPIType()) : true
         );
 
         return Iterables.all(booleanExpressions, Predicates.equalTo(true));

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulatorTests.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulatorTests.java
@@ -33,11 +33,27 @@ public class DefaultAndroidEmulatorTests {
   }
 
   @Test
-  public void testShouldBeAbleToStartEmulator() throws Exception {
+  public void testShouldBeAbleToStartGoogleEmulator() throws Exception {
     AndroidEmulator emulator =
         new DefaultAndroidEmulator("l10n", "X86", new Dimension(320, 480), "16", "Nexus 5", new File(
             FileUtils.getUserDirectory(), ".android" + File.separator + "avd" + File.separator
-                + "l10n.avd"));
+                + "l10n.avd"), "Google");
+
+    Assert.assertTrue("expecting emulators exists: ", emulator.isEmulatorAlreadyExistent());
+    Assert.assertFalse("expecting emulator is not yet started: ", emulator.isEmulatorStarted());
+
+    emulator.start(new Locale("en_GB"), 5554, null);
+    Assert.assertTrue(emulator.isEmulatorStarted());
+    emulator.stop();
+    Assert.assertFalse(emulator.isEmulatorStarted());
+  }
+
+  @Test
+  public void testShouldBeAbleToStartAndroidEmulator() throws Exception {
+    AndroidEmulator emulator =
+        new DefaultAndroidEmulator("l10n", "X86", new Dimension(320, 480), "16", "Nexus 5", new File(
+            FileUtils.getUserDirectory(), ".android" + File.separator + "avd" + File.separator
+                + "l10n.avd"), "Android");
 
     Assert.assertTrue("expecting emulators exists: ", emulator.isEmulatorAlreadyExistent());
     Assert.assertFalse("expecting emulator is not yet started: ", emulator.isEmulatorStarted());

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreFixture.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreFixture.java
@@ -49,10 +49,11 @@ public class DeviceStoreFixture {
   }
 
   protected static DefaultAndroidEmulator anEmulator(String name, DeviceTargetPlatform platform,
-      boolean isEmulatorStarted) throws AndroidDeviceException {
+      String apiType, boolean isEmulatorStarted) throws AndroidDeviceException {
     DefaultAndroidEmulator emulator = mock(DefaultAndroidEmulator.class);
     when(emulator.getAvdName()).thenReturn(name);
     when(emulator.getModel()).thenReturn("Nexus 5");
+    when(emulator.getAPIType()).thenReturn(apiType);
     when(emulator.getTargetPlatform()).thenReturn(platform);
     when(emulator.isEmulatorStarted()).thenReturn(isEmulatorStarted);
     when(emulator.isDeviceReady()).thenReturn(false);
@@ -75,11 +76,18 @@ public class DeviceStoreFixture {
     capabilities.setScreenSize("320x480");
     return capabilities;
   }
-
   protected static SelendroidCapabilities withWrongModelCapabilities() {
     SelendroidCapabilities capabilities = new SelendroidCapabilities();
     capabilities.setPlatformVersion(DeviceTargetPlatform.ANDROID16);
     capabilities.setModel("Nexus 7");
+    capabilities.setScreenSize("320x480");
+    return capabilities;
+  }
+
+  protected static SelendroidCapabilities withGoogleAPITypeCapabilities() {
+    SelendroidCapabilities capabilities = new SelendroidCapabilities();
+    capabilities.setPlatformVersion(DeviceTargetPlatform.ANDROID16);
+    capabilities.setAPIType("Google");
     capabilities.setScreenSize("320x480");
     return capabilities;
   }

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/server/model/DeviceStoreTest.java
@@ -19,6 +19,7 @@ import static io.selendroid.standalone.server.model.DeviceStoreFixture.anEmulato
 import static io.selendroid.standalone.server.model.DeviceStoreFixture.withDefaultCapabilities;
 import static io.selendroid.standalone.server.model.DeviceStoreFixture.withModelCapabilities;
 import static io.selendroid.standalone.server.model.DeviceStoreFixture.withWrongModelCapabilities;
+import static io.selendroid.standalone.server.model.DeviceStoreFixture.withGoogleAPITypeCapabilities;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -64,7 +65,7 @@ public class DeviceStoreTest {
 
   @Test
   public void shouldAddStartedEmulator() throws Exception {
-    AndroidEmulator emulator = anEmulator("de", DeviceTargetPlatform.ANDROID10, false);
+    AndroidEmulator emulator = anEmulator("de", DeviceTargetPlatform.ANDROID10, null, false);
 
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Collections.singletonList(emulator));
@@ -86,7 +87,7 @@ public class DeviceStoreTest {
 
   @Test
   public void shouldReleaseActiveEmulators() throws Exception {
-    AndroidEmulator deEmulator = anEmulator("de", DeviceTargetPlatform.ANDROID16, false);
+    AndroidEmulator deEmulator = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, false);
     when(deEmulator.getPort()).thenReturn(5554);
 
     EmulatorPortFinder finder = mock(EmulatorPortFinder.class);
@@ -107,7 +108,7 @@ public class DeviceStoreTest {
 
   @Test
   public void shouldReleaseActiveEmulatorButKeepItRunning() throws Exception {
-    AndroidEmulator deEmulator = anEmulator("de", DeviceTargetPlatform.ANDROID16, false);
+    AndroidEmulator deEmulator = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, false);
     when(deEmulator.getPort()).thenReturn(5554);
 
     EmulatorPortFinder finder = mock(EmulatorPortFinder.class);
@@ -130,9 +131,9 @@ public class DeviceStoreTest {
 
   @Test
   public void shouldRegisterMultipleNotStatedEmulators() throws Exception {
-    AndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID10, false);
-    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, false);
-    AndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, false);
+    AndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID10, null, false);
+    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, null, false);
+    AndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, false);
 
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator10, enEmulator10,
@@ -152,9 +153,9 @@ public class DeviceStoreTest {
 
   @Test
   public void shouldRegisterStartedAndStoppedEmulators() throws Exception {
-    AndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID10, false);
-    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, true);
-    AndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, true);
+    AndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID10, null, false);
+    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, null, true);
+    AndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, true);
 
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator10, enEmulator10,
@@ -178,8 +179,8 @@ public class DeviceStoreTest {
 
   @Test
   public void shouldNotIgnoreRunningEmulators() throws Exception {
-    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, true);
-    AndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, true);
+    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, null, true);
+    AndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, true);
 
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {enEmulator10, deEmulator16}));
@@ -209,7 +210,7 @@ public class DeviceStoreTest {
   @Test
   public void shouldFindSwitchedOffEmulator() throws Exception {
     // prepare device store
-    DefaultAndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, false);
+    DefaultAndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, false);
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator16}));
 
@@ -224,7 +225,7 @@ public class DeviceStoreTest {
   @Test
   public void shouldThrowAnExceptionIfTargetPlatformIsMissingInCapabilities() throws Exception {
     // prepare device store
-    DefaultAndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, false);
+    DefaultAndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, false);
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator16}));
 
@@ -243,8 +244,8 @@ public class DeviceStoreTest {
   @Test
   public void shouldNotFindDeviceIfTargetPlatformIsNotSuported() throws Exception {
     // prepare device store
-    DefaultAndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID10, false);
-    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, false);
+    DefaultAndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID10, null, false);
+    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, null, false);
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator10, enEmulator10}));
 
@@ -264,8 +265,8 @@ public class DeviceStoreTest {
   @Test
   public void shouldNotFindDeviceIfScreenSizeIsNotSupported() throws Exception {
     // prepare device store
-    DefaultAndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID16, false);
-    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, false);
+    DefaultAndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, false);
+    AndroidEmulator enEmulator10 = anEmulator("en", DeviceTargetPlatform.ANDROID10, null, false);
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator10, enEmulator10}));
 
@@ -298,7 +299,7 @@ public class DeviceStoreTest {
 
   @Test
   public void testShouldBeAbleToUpdateDevices() throws Exception {
-    AndroidEmulator emulator = anEmulator("de", DeviceTargetPlatform.ANDROID10, false);
+    AndroidEmulator emulator = anEmulator("de", DeviceTargetPlatform.ANDROID10, null, false);
 
     Map<String,String> prop = new HashMap(); // used for phone properties
     AndroidDevice device = anDevice("01234ABC", prop);
@@ -325,7 +326,7 @@ public class DeviceStoreTest {
 
   @Test
   public void testShouldBeAbleToRemoveDevices() throws Exception {
-    DefaultAndroidEmulator emulator = anEmulator("de", DeviceTargetPlatform.ANDROID10, false);
+    DefaultAndroidEmulator emulator = anEmulator("de", DeviceTargetPlatform.ANDROID10, null, false);
     AndroidDevice device = anDevice("en", DeviceTargetPlatform.ANDROID16);
 
     DeviceStore store = new DeviceStore(EMULATOR_PORT, anDeviceManager());
@@ -470,7 +471,7 @@ public class DeviceStoreTest {
 
   @Test
   public void shouldNotRemoveAnEmulator() throws Exception {
-    DefaultAndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID16, false);
+    DefaultAndroidEmulator deEmulator10 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, false);
     DeviceStore store = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     store.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator10}));
 
@@ -486,7 +487,7 @@ public class DeviceStoreTest {
   @Test
   public void shouldFindStartedEmulator() throws Exception {
     // prepare device store
-    DefaultAndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, true);
+    DefaultAndroidEmulator deEmulator16 = anEmulator("de", DeviceTargetPlatform.ANDROID16, null, true);
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {deEmulator16}));
 
@@ -501,7 +502,7 @@ public class DeviceStoreTest {
   @Test
   public void shouldFindAnEmulatorWithSpecifiedModel() throws Exception {
     // adding Nexus 5 to device store
-    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, true);
+    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, null, true);
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {emulator}));
 
@@ -527,7 +528,7 @@ public class DeviceStoreTest {
   @Test
   public void shouldNotFindAnEmulatorWithWrongModel() throws Exception {
     // adding Nexus 5 to device store
-    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, true);
+    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, null, true);
     DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
     deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {emulator}));
 
@@ -549,6 +550,48 @@ public class DeviceStoreTest {
 
     try {
       deviceStore.findAndroidDevice(withWrongModelCapabilities());
+      Assert.fail();
+    } catch (DeviceStoreException e) {
+      assertThat(
+          e.getMessage(),
+          equalTo("No devices are found. This can happen if the devices are in use or no device screen matches the required capabilities."));
+    }
+  }
+
+  @Test
+  public void shouldFindAnEmulatorWithMatchedAPIType() throws Exception {
+    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, "Google", true);
+    DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
+    deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {emulator}));
+
+    AndroidDevice foundEmulator = deviceStore.findAndroidDevice(withGoogleAPITypeCapabilities());
+    assertThat(foundEmulator, equalTo((AndroidDevice) emulator));
+  }
+
+  @Test
+  public void shouldNotFindAnEmulatorWithWrongAPIType() throws Exception {
+    DefaultAndroidEmulator emulator = anEmulator("emulator", DeviceTargetPlatform.ANDROID16, "Android", true);
+    DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
+    deviceStore.addEmulators(Arrays.asList(new AndroidEmulator[] {emulator}));
+
+    try {
+      deviceStore.findAndroidDevice(withGoogleAPITypeCapabilities());
+      Assert.fail();
+    } catch (DeviceStoreException e) {
+      assertThat(
+          e.getMessage(),
+          equalTo("No devices are found. This can happen if the devices are in use or no device screen matches the required capabilities."));
+    }
+  }
+
+  @Test
+  public void shouldNotFindARealDeviceWithAPIType() throws Exception {
+    AndroidDevice device = anDevice("RealDevice", DeviceTargetPlatform.ANDROID16);
+    DeviceStore deviceStore = new DeviceStore(EMULATOR_PORT, anDeviceManager());
+    deviceStore.addDevice(device);
+
+    try {
+      deviceStore.findAndroidDevice(withGoogleAPITypeCapabilities());
       Assert.fail();
     } catch (DeviceStoreException e) {
       assertThat(


### PR DESCRIPTION
Since some applications are written for Google API, they would fail to
install on an emulator with Android API, and vice versa. This implementation
will add "apiType" option to the selendroid capabilties to allow users
to select a specific  emulator with the desired (Google/Android) API type to 
run their tests.

Users can safely ignore this option if the application under test is not
sensitive to either API type to run.

Signed-off-by: Binh Vu <bvu@paypal.com>