### PR TITLE
Fix native view search with multiple top level views

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
@@ -268,28 +268,31 @@ public abstract class AbstractNativeElementContext
   }
 
 
-  public List<AndroidElement> searchViews(List<View> roots,
+  /** visible for testing */
+  protected static List<AndroidElement> searchViews(AbstractNativeElementContext context, List<View> roots,
       Predicate predicate, boolean findJustOne) {
     List<AndroidElement> elements = new ArrayList<AndroidElement>();
     if (roots == null || roots.isEmpty()) {
       return elements;
     }
     ArrayDeque<View> queue = new ArrayDeque<View>();
-    queue.addAll(roots);
 
-    while (!queue.isEmpty()) {
-      View view = queue.pop();
-      if (predicate.apply(view)) {
-        elements.add(newAndroidElement(view));
-        if (findJustOne) {
-          break;
+    for (View root : roots) {
+      queue.add(root);
+      while (!queue.isEmpty()) {
+        View view = queue.pop();
+        if (predicate.apply(view)) {
+          elements.add(context.newAndroidElement(view));
+          if (findJustOne) {
+            break;
+          }
         }
-      }
-      if (view instanceof ViewGroup) {
-        ViewGroup group = (ViewGroup)view;
-        int childrenCount = group.getChildCount();
-        for (int index = 0; index < childrenCount; index++) {
-          queue.add(group.getChildAt(index));
+        if (view instanceof ViewGroup) {
+          ViewGroup group = (ViewGroup) view;
+          int childrenCount = group.getChildCount();
+          for (int index = 0; index < childrenCount; index++) {
+            queue.add(group.getChildAt(index));
+          }
         }
       }
     }
@@ -297,11 +300,11 @@ public abstract class AbstractNativeElementContext
   }
 
   private List<AndroidElement> findAllByPredicate(Predicate predicate) {
-     return searchViews(getTopLevelViews(), predicate, false);
+     return searchViews(this, getTopLevelViews(), predicate, false);
   }
 
   private AndroidElement findFirstByPredicate(Predicate predicate) {
-    List<AndroidElement> list = searchViews(getTopLevelViews(), predicate, true);
+    List<AndroidElement> list = searchViews(this, getTopLevelViews(), predicate, true);
     if (list != null && !list.isEmpty()) {
       return list.get(0);
     }

--- a/selendroid-server/src/test/java/io/selendroid/server/model/internal/AbstractNativeElementContextTest.java
+++ b/selendroid-server/src/test/java/io/selendroid/server/model/internal/AbstractNativeElementContextTest.java
@@ -1,0 +1,249 @@
+package io.selendroid.server.model.internal;
+
+import android.view.View;
+import android.view.ViewGroup;
+import com.android.internal.util.Predicate;
+import io.selendroid.server.model.AndroidElement;
+import io.selendroid.server.model.AndroidNativeElement;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AbstractNativeElementContextTest {
+    final static int NO_MATCH = 0;
+    final static int MATCH = 42;
+    final static Predicate<View> FIND_MATCH = new TestIdPredicate(MATCH);
+
+    /**
+     * No nodes matches.
+     *
+     *    a
+     *   / \
+     *  b   c
+     */
+    public void itFindsNothingIfNoNodeMatches() {
+        ViewGroup b = ignore();
+        ViewGroup c = ignore();
+        ViewGroup a = ignore(b, c);
+
+        List<View> views = searchViews(a);
+
+        assertEquals(0, views.size());
+    }
+
+    /**
+     * Root matches and no children.
+     *
+     *   A (1)
+     */
+    @Test
+    public void itFindsTheRoot() {
+        ViewGroup root = match();
+
+        List<View> views = searchViews(root);
+
+        assertFoundViews(views, root);
+    }
+
+    /**
+     * Root, doesn't match, but children on various levels do.
+     *
+     *           a
+     *        /     \
+     *       b       C (1)
+     *    /     \      \
+     *   D(2)    e      F (3)
+     */
+    @Test
+    public void itFindsChildrenOfTheRoot() {
+        // Bottom
+        ViewGroup D = match();
+        ViewGroup e = ignore();
+        ViewGroup F = match();
+
+        // Middle
+        ViewGroup b = ignore(D, e);
+        ViewGroup C = match(F);
+
+        // Root
+        ViewGroup root = ignore(b, C);
+
+        List<View> views = searchViews(root);
+        assertFoundViews(views, C, D, F);
+    }
+
+    /**
+     * Currently selendroid searches all top levels views, ordered by the one
+     * that was last painted first. If this happens we should first return
+     * all the matching children from the first (visible?) tree, then from the
+     * second one, and so on.
+     *
+     *           a                       g
+     *        /     \                 /     \
+     *       b       c              h        I (3)
+     *    /     \      \         /     \      \
+     *   D(1)    e      F (2)   J(4)    k      L (5)
+     */
+    @Test
+    public void itReturnsTheChildrenInTheOrderOfTheRoots() {
+        // Bottom 1
+        ViewGroup D = match();
+        ViewGroup e = ignore();
+        ViewGroup F = match();
+
+        // Middle 1
+        ViewGroup b = ignore(D, e);
+        ViewGroup c = ignore(F);
+
+        // Root 1
+        ViewGroup root1 = ignore(b, c);
+
+        // Bottom 2
+        ViewGroup J = match();
+        ViewGroup k = ignore();
+        ViewGroup L = match();
+
+        // Middle 2
+        ViewGroup h = ignore(J, k);
+        ViewGroup I = match(L);
+
+        // Root 2
+        ViewGroup root2 = ignore(h, I);
+
+        List<View> views = searchViews(root1, root2);
+        assertFoundViews(views, D, F, I, J, L);
+    }
+
+    /**
+     * The first hierarchy has no match, but the second one has.
+     *
+     *           a                       g
+     *        /     \                 /     \
+     *       b       c              h        I (1)
+     *    /     \      \         /     \      \
+     *   d       e      F       J(2)    k      L (3)
+     */
+    @Test
+    public void itReturnsChildrenFromTheSecondRoot() {
+        // Bottom 1
+        ViewGroup d = ignore();
+        ViewGroup e = ignore();
+        ViewGroup f = ignore();
+
+        // Middle 1
+        ViewGroup b = ignore(d, e);
+        ViewGroup c = ignore(f);
+
+        // Root 1
+        ViewGroup root1 = ignore(b, c);
+
+        // Bottom 2
+        ViewGroup J = match();
+        ViewGroup k = ignore();
+        ViewGroup L = match();
+
+        // Middle 2
+        ViewGroup h = ignore(J, k);
+        ViewGroup I = match(L);
+
+        // Root 2
+        ViewGroup root2 = ignore(h, I);
+
+        List<View> views = searchViews(root1, root2);
+        assertFoundViews(views, I, J, L);
+    }
+
+    private static void assertFoundViews(List<View> foundViews, View ...expectedViewsInOrder) {
+        assertEquals(expectedViewsInOrder.length, foundViews.size());
+
+        for (int i = 0; i < expectedViewsInOrder.length; i++) {
+            assertEquals(expectedViewsInOrder[i], foundViews.get(i));
+        }
+    }
+
+    /**
+     * @return A node that gets returned by the search
+     */
+    private ViewGroup match(ViewGroup ...children) {
+        return mockViewGroup(MATCH, children);
+    }
+
+    /**
+     * @return A node that does not get returned by the search
+     */
+    private ViewGroup ignore(ViewGroup ...children) {
+        return mockViewGroup(NO_MATCH, children);
+    }
+
+    /**
+     * Helper to do the actual searching.
+     */
+    private static List<View> searchViews(View ...roots) {
+        List<View> rootViews = new ArrayList<View>(Arrays.asList(roots));
+        List<AndroidElement> elements = AbstractNativeElementContext.searchViews(
+                mockContext(),
+                rootViews,
+                FIND_MATCH,
+                false);
+
+        List<View> foundViews = new ArrayList<View>();
+        for (AndroidElement element : elements) {
+            foundViews.add(((AndroidNativeElement) element).getView());
+        }
+        return foundViews;
+    }
+
+    private static AbstractNativeElementContext mockContext() {
+        AbstractNativeElementContext context = mock(AbstractNativeElementContext.class);
+        when(context.newAndroidElement(any(View.class))).then(new Answer<AndroidElement>() {
+            @Override
+            public AndroidElement answer(InvocationOnMock invocationOnMock) throws Throwable {
+                AndroidNativeElement element = mock(AndroidNativeElement.class);
+
+                when(element.getView()).thenReturn((ViewGroup) invocationOnMock.getArguments()[0]);
+
+                return element;
+            }
+
+        });
+        return context;
+    }
+
+    static class TestIdPredicate implements Predicate<View> {
+        private int id;
+        protected TestIdPredicate(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean apply(View view) {
+            return view.getId() == id;
+        }
+    }
+
+    private ViewGroup mockViewGroup(int id, ViewGroup ...viewChildren) {
+        ViewGroup view = mock(ViewGroup.class);
+        final ArrayList<ViewGroup> children = new ArrayList<ViewGroup>(Arrays.asList(viewChildren));
+
+        when(view.getId()).thenReturn(id);
+        when(view.getChildCount()).thenReturn(children.size());
+        when(view.getChildAt(anyInt())).then(new Answer<View>() {
+            @Override
+            public View answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return children.get((Integer) invocationOnMock.getArguments()[0]);
+            }
+        });
+
+        return view;
+    }
+}


### PR DESCRIPTION
The current implementation of `AbstractNativeElementContext#searchViews`
can end up looking at multiple top level views. Selendroid makes sure
that the top level views passed to the `searchViews()` method are
ordered by when they were last painted on the screen. Searching for
views is then done by a breadth-first search to return elements higher
up in the view hierarchy first.

Given the two top level views below, the previous version of the
`searchViews()` method would return the following nodes in the order:
`[I, D, F, J, L]`.

```
        a                     g
     /     \              /     \
    b       c             h       I (1)
 /     \     \         /     \     \
D(2)    e     F (3)    J(4)   k     L (5)
```
*Capital letters are matching nodes.*

After this patch the method will return: `[D, F, I, J, L]`.
```
        a                     g
     /     \              /     \
    b       c             h       I (3)
 /     \     \         /     \     \
D(1)    e     F (2)    J(4)   k     L (5)
```

The behavior now changed from doing a breadth-first search spanning all
top level views at once, to doing it per view, returning the child
elements grouped per view.

This change has the biggest impact on finding one element. That will use
the same method, but return the first element of the list. In the
example above the value will change from `I' to `D`. This means you
always end up with a child element of the last drawn top level view,
instead of the child element that is highest up the view hierarchy
accross all views.