### PR TITLE
fix registration of selendroid server into a selenium grid

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/grid/SelfRegisteringRemote.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/grid/SelfRegisteringRemote.java
@@ -105,6 +105,7 @@ public class SelfRegisteringRemote {
             capa.put(SelendroidCapabilities.AUT, driver.getSupportedApps().getJSONObject(x).get(APP_ID));
           }
           capa.put(CapabilityType.PLATFORM, "ANDROID");
+          capa.put(SelendroidCapabilities.PLATFORM_NAME, "android");
           capa.put(CapabilityType.VERSION, version);
           capa.put("maxInstances", config.getMaxInstances());
           caps.put(capa);


### PR DESCRIPTION
The SelendroidCapabilities requires the selendroid grid node to have the capability: platformName => android