### PR TITLE
Reverted the 'adb.terminate()' call (back into if condition). 

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultDeviceManager.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultDeviceManager.java
@@ -84,11 +84,9 @@ public class DefaultDeviceManager extends Thread implements IDeviceChangeListene
           throw new RuntimeException(e);
         }
       }
-      if (devices.length > 0) {
-        for (int i = 0; i < devices.length; i++) {
-          deviceConnected(devices[i]);
-          log.info("my devices: " + devices[i].getAvdName());
-        }
+      for (IDevice device : devices) {
+        deviceConnected(device);
+        log.info("my devices: " + device.getAvdName());
       }
     }
 
@@ -108,8 +106,8 @@ public class DefaultDeviceManager extends Thread implements IDeviceChangeListene
     AndroidDebugBridge.removeDeviceChangeListener(this);
     if (!shouldKeepAdbAlive) {
       AndroidDebugBridge.disconnectBridge();
+      AndroidDebugBridge.terminate();
     }
-    AndroidDebugBridge.terminate();
     log.info("stopping Device Manager");
     // TODO add thread interrupt and join handling
   }


### PR DESCRIPTION
As I've noticed in my testNG suite which uses Selendroid standalone, the commit f735a8a breaks the test execution of more than 1 test in a suite. With this change it works again.
The need for the original change was due to some orphaned processes upon test termination. This has to be addressed separately (and shouldn't break any already present functionality).

Also:
Simplified the logic of iterating through devices in DefaultDeviceManager#initializeAdbConnection()