### PR TITLE
Introduce Predicate and AndroidElement factories

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElementFactory.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElementFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import io.selendroid.server.ServerInstrumentation;
+import io.selendroid.server.android.KeySender;
+
+public interface AndroidNativeElementFactory {
+
+  public AndroidNativeElement createAndroidNativeElement(
+      View view,
+      ServerInstrumentation instrumentation,
+      KeySender keys,
+      KnownElements ke);
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/ClassPredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/ClassPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import com.android.internal.util.Predicate;
+import io.selendroid.server.common.exceptions.NoSuchElementException;
+
+public class ClassPredicate implements Predicate<View> {
+
+  protected final String using;
+
+  public ClassPredicate(String using) {
+    this.using = using;
+  }
+
+  @Override
+  public boolean apply(View to) {
+    try {
+      return Class.forName(using).isInstance(to);
+    } catch (ClassNotFoundException e) {
+      throw new NoSuchElementException("The view class '" + using + "' was not found.");
+    }
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/ContentDescriptionPredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/ContentDescriptionPredicate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import com.android.internal.util.Predicate;
+
+public class ContentDescriptionPredicate implements Predicate<View> {
+
+  protected final String using;
+
+  ContentDescriptionPredicate(String using) {
+    this.using = using;
+  }
+
+  public boolean apply(View to) {
+    CharSequence contentDescription = to.getContentDescription();
+    if (using == null) {
+      return contentDescription == null;
+    } else {
+      return contentDescription != null && using.contentEquals(contentDescription);
+    }
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/DefaultAndroidNativeElementFactory.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/DefaultAndroidNativeElementFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import io.selendroid.server.ServerInstrumentation;
+import io.selendroid.server.android.KeySender;
+
+class DefaultAndroidNativeElementFactory implements AndroidNativeElementFactory {
+
+  @Override
+  public AndroidNativeElement createAndroidNativeElement(
+      View view,
+      ServerInstrumentation instrumentation,
+      KeySender keys,
+      KnownElements ke) {
+    return new AndroidNativeElement(view, instrumentation, keys, ke);
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/Factories.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/Factories.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+
+import io.selendroid.server.util.Preconditions;
+
+public class Factories {
+
+  private static AndroidNativeElementFactory androidNativeElementFactory = null;
+  private static PredicatesFactory predicatesFactory = null;
+
+  public static void set(AndroidNativeElementFactory factory) {
+    androidNativeElementFactory = Preconditions.checkNotNull(factory);
+  }
+
+  public static AndroidNativeElementFactory getAndroidNativeElementFactory() {
+    if (androidNativeElementFactory == null) {
+      set(new DefaultAndroidNativeElementFactory());
+    }
+    return androidNativeElementFactory;
+  }
+
+  public static void set(PredicatesFactory factory) {
+    predicatesFactory = Preconditions.checkNotNull(factory);
+  }
+
+  public static PredicatesFactory getPredicatesFactory() {
+    if (predicatesFactory == null) {
+      set(new PredicatesFactory());
+    }
+    return predicatesFactory;
+
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/IdPredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/IdPredicate.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import com.android.internal.util.Predicate;
+import io.selendroid.server.android.ViewHierarchyAnalyzer;
+
+public class IdPredicate implements Predicate<View> {
+
+  protected final String using;
+
+  public IdPredicate(String using) {
+    this.using = using;
+  }
+
+  @Override
+  public boolean apply(View to) {
+    return ViewHierarchyAnalyzer.getNativeId(to).equalsIgnoreCase("id/" + using);
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/PartialTextPredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/PartialTextPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import android.widget.TextView;
+import com.android.internal.util.Predicate;
+import io.selendroid.server.util.SelendroidLogger;
+
+public class PartialTextPredicate implements Predicate<View> {
+
+  protected final String using;
+
+  public PartialTextPredicate(String using) {
+    this.using = using;
+  }
+  public boolean apply(View to) {
+    SelendroidLogger.info("Finding by partial text: " + using);
+    if (to instanceof TextView) {
+      String viewText = ((TextView) to).getText().toString();
+      return viewText.indexOf(using) >= 0;
+    }
+    return false;
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/PredicatesFactory.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/PredicatesFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+
+import android.view.View;
+import com.android.internal.util.Predicate;
+
+public class PredicatesFactory {
+
+  public Predicate<View> createIdPredicate(String using) {
+    return new IdPredicate(using);
+  }
+
+  public Predicate<View> createContentDescriptionPredicate(String using) {
+    return new ContentDescriptionPredicate(using);
+  }
+
+  public Predicate<View> createTextPredicate(String using) {
+    return new TextPredicate(using);
+  }
+
+  public Predicate<View> createPartialTextPredicate(String using) {
+    return new PartialTextPredicate(using);
+  }
+
+  public Predicate<View> createTagNamePredicate(String using) {
+    return new TagNamePredicate(using);
+  }
+
+  public Predicate<View> createClassPredicate(String using) {
+    return new ClassPredicate(using);
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/TagNamePredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/TagNamePredicate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import com.android.internal.util.Predicate;
+
+public class TagNamePredicate implements Predicate<View> {
+
+  protected final String using;
+
+  public TagNamePredicate(String using) {
+    this.using = using;
+  }
+
+  public boolean apply(View to) {
+    return to.getClass().getSimpleName().equals(using);
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/TextPredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/TextPredicate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import android.widget.TextView;
+import com.android.internal.util.Predicate;
+
+public class TextPredicate implements Predicate<View> {
+
+  protected String using;
+
+  public TextPredicate(String using) {
+    this.using = using;
+  }
+
+  public boolean apply(View to) {
+    if (to instanceof TextView) {
+      return String.valueOf(((TextView) to).getText()).equals(using);
+    }
+    return false;
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/internal/execute_native/FindElementByAndroidTag.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/internal/execute_native/FindElementByAndroidTag.java
@@ -19,6 +19,7 @@ import io.selendroid.server.android.KeySender;
 import io.selendroid.server.android.ViewHierarchyAnalyzer;
 import io.selendroid.server.model.AndroidNativeElement;
 import io.selendroid.server.model.KnownElements;
+import io.selendroid.server.model.Factories;
 import io.selendroid.server.util.Preconditions;
 import io.selendroid.server.util.SelendroidLogger;
 
@@ -85,7 +86,8 @@ private AndroidNativeElement newAndroidElement(View view) {
         return element;
       }
     }
-    AndroidNativeElement e = new AndroidNativeElement(view, serverInstrumentation, keys, knownElements);
+    AndroidNativeElement e = Factories.getAndroidNativeElementFactory()
+        .createAndroidNativeElement(view, serverInstrumentation, keys, knownElements);
     knownElements.add(e);
     return e;
   }

--- a/selendroid-server/src/test/java/io/selendroid/server/model/KnownElementsTest.java
+++ b/selendroid-server/src/test/java/io/selendroid/server/model/KnownElementsTest.java
@@ -19,11 +19,6 @@ import android.webkit.WebView;
 import io.selendroid.server.ServerInstrumentation;
 import io.selendroid.server.android.InstrumentedKeySender;
 import io.selendroid.server.android.KeySender;
-import io.selendroid.server.model.AndroidElement;
-import io.selendroid.server.model.AndroidNativeElement;
-import io.selendroid.server.model.AndroidWebElement;
-import io.selendroid.server.model.KnownElements;
-import io.selendroid.server.model.SelendroidWebDriver;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -143,7 +138,7 @@ public class KnownElementsTest {
 
     ServerInstrumentation instrumentation = mock(ServerInstrumentation.class);
     KeySender keys = new InstrumentedKeySender(instrumentation);
-    return new AndroidNativeElement(view, instrumentation, keys, ke);
+    return Factories.getAndroidNativeElementFactory().createAndroidNativeElement(view, instrumentation, keys, ke);
   }
 
   private AndroidElement createWebElement(String id, KnownElements ke) {


### PR DESCRIPTION
Summary:
Custom android views sometimes require specific behaviours.
This diff introduce factories for predicates and android elements, allowing test
developers to extend them in order to setup specific behaviours at bootstrap.

Test Plan: Ran with custom views and checked using custom factories worked.

Differential Revision: https://reviews.facebook.net/D33639