### PR TITLE
Pass Tests on Windows

### DIFF
--- a/selendroid-server-common/src/test/java/io/selendroid/server/common/SelendroidResponseTest.java
+++ b/selendroid-server-common/src/test/java/io/selendroid/server/common/SelendroidResponseTest.java
@@ -44,7 +44,7 @@ public class SelendroidResponseTest {
     assertEquals(StatusCode.UNKNOWN_ERROR.getCode(), rendered.getLong("status"));
     assertEquals("java.lang.RuntimeException", rendered.getJSONObject("value").getString("class"));
     Assert.assertTrue(rendered.getJSONObject("value").getString("message").startsWith(
-        "java.lang.RuntimeException\n\tat io.selendroid.server.common.SelendroidResponseTest"));
+        String.format("java.lang.RuntimeException%n\tat io.selendroid.server.common.SelendroidResponseTest")));
   }
 
   @Test
@@ -56,6 +56,6 @@ public class SelendroidResponseTest {
     assertEquals(StatusCode.UNKNOWN_ERROR.getCode(), rendered.getLong("status"));
     assertEquals("java.lang.RuntimeException", rendered.getJSONObject("value").getString("class"));
     Assert.assertTrue(rendered.getJSONObject("value").getString("message").startsWith(
-        "CATCH_ALL: java.lang.RuntimeException\n\tat io.selendroid.server.common.SelendroidResponseTest"));
+            String.format("CATCH_ALL: java.lang.RuntimeException%n\tat io.selendroid.server.common.SelendroidResponseTest")));
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -568,10 +568,10 @@ public abstract class AbstractDevice implements AndroidDevice {
     String psOutput = runAdbCommand("shell ps");
     StringBuilder sb = new StringBuilder();
     boolean isFirstHeaderLine = true;
-    for (String line: Splitter.on("\n").split(psOutput)) {
+    for (String line: Splitter.on(System.getProperty("line.separator")).split(psOutput)) {
       boolean isThirdPartyProcess = line.contains(".") && !line.contains("com.android");
       if (isFirstHeaderLine || isThirdPartyProcess) {
-        sb.append(line + "\n");
+        sb.append(line + System.getProperty("line.separator"));
       }
       isFirstHeaderLine = false;
     }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -548,16 +548,15 @@ public abstract class AbstractDevice implements AndroidDevice {
   /** {@inheritdoc} */
   public String getCrashLog() {
     String crashLogFileName = ExternalStorageFile.APP_CRASH_LOG.toString();
-    File crashLogFile = new File(getExternalStoragePath(), crashLogFileName);
 
     // The "test" utility doesn't exist on all devices so we'll check the output of ls.
-    String crashLogDirPath = crashLogFile.getParentFile().getAbsolutePath();
+    String crashLogDirPath = getExternalStoragePath();
     if (!crashLogDirPath.endsWith("/")) {
       crashLogDirPath += "/";  // Make sure it ends with '/' so we're listing directory contents.
     }
     String directoryList = executeCommandQuietly(adbCommand("shell", "ls", crashLogDirPath));
     if (directoryList.contains(crashLogFileName)) {
-      return executeCommandQuietly(adbCommand("shell", "cat", crashLogFile.getAbsolutePath()));
+      return executeCommandQuietly(adbCommand("shell", "cat", crashLogDirPath + crashLogFileName));
     }
 
     return "";

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
@@ -49,9 +49,15 @@ public class AbstractDeviceTest {
     when(device.getCrashLog()).thenCallRealMethod();
     when(
         device.executeCommandQuietly(argThat(matchesCmdLine("adb shell ls /storage/"))))  // The trailing '/' is key
-        .thenReturn("some_file\nappcrash.log\nanother_file");
+        .thenReturn(String.format("some_file%nappcrash.log%nanother_file"));
+    when(
+        device.executeCommandQuietly(argThat(matchesCmdLine("adb.exe shell ls C:\\storage/"))))  // The trailing '/' is key
+        .thenReturn(String.format("some_file%nappcrash.log%nanother_file"));
     when(
         device.executeCommandQuietly(argThat(matchesCmdLine("adb shell cat /storage/appcrash.log"))))
+        .thenReturn("crash log contents");
+    when(
+        device.executeCommandQuietly(argThat(matchesCmdLine("adb.exe shell cat C:\\storage\\appcrash.log"))))
         .thenReturn("crash log contents");
 
     assertEquals("crash log contents", device.getCrashLog());
@@ -62,20 +68,23 @@ public class AbstractDeviceTest {
     AbstractDevice device = mock(AbstractDevice.class);
     when(device.listRunningThirdPartyProcesses()).thenCallRealMethod();
     when(device.runAdbCommand(anyString())).thenCallRealMethod();
-    String psOutput =
-        "PID NAME\n" +
-        "11 com.example.myapp\n" +
-        "123 com.android.calendar\n" +
-        "15 com.example.another\n" +
-        "1 zygote\n" +
-        "23 /system/bin/mediaserver";
+    String psOutput = String.format(
+        "PID NAME%n" +
+        "11 com.example.myapp%n" +
+        "123 com.android.calendar%n" +
+        "15 com.example.another%n" +
+        "1 zygote%n" +
+        "23 /system/bin/mediaserver");
     when(
         device.executeCommandQuietly(argThat(matchesCmdLine("adb shell ps"))))
         .thenReturn(psOutput);
-    String expected =
-        "PID NAME\n" +
-        "11 com.example.myapp\n" +
-        "15 com.example.another\n";
+    when(
+        device.executeCommandQuietly(argThat(matchesCmdLine("adb.exe shell ps"))))
+        .thenReturn(psOutput);
+    String expected = String.format(
+        "PID NAME%n" +
+        "11 com.example.myapp%n" +
+        "15 com.example.another%n");
     assertEquals(expected, device.listRunningThirdPartyProcesses());
   }
 }

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
@@ -21,6 +21,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
+import java.util.regex.Pattern;
+
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -32,7 +34,7 @@ public class AbstractDeviceTest {
         if (!(cmdLine instanceof CommandLine)) {
           return false;
         }
-        return cmdLine.toString().endsWith(cmdString);
+        return Pattern.matches(cmdString, cmdLine.toString());
       }
 
       @Override
@@ -48,16 +50,10 @@ public class AbstractDeviceTest {
     when(device.getExternalStoragePath()).thenReturn("/storage");
     when(device.getCrashLog()).thenCallRealMethod();
     when(
-        device.executeCommandQuietly(argThat(matchesCmdLine("adb shell ls /storage/"))))  // The trailing '/' is key
+        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)? shell ls /storage/$"))))  // The trailing '/' is key
         .thenReturn(String.format("some_file%nappcrash.log%nanother_file"));
     when(
-        device.executeCommandQuietly(argThat(matchesCmdLine("adb.exe shell ls C:\\storage/"))))  // The trailing '/' is key
-        .thenReturn(String.format("some_file%nappcrash.log%nanother_file"));
-    when(
-        device.executeCommandQuietly(argThat(matchesCmdLine("adb shell cat /storage/appcrash.log"))))
-        .thenReturn("crash log contents");
-    when(
-        device.executeCommandQuietly(argThat(matchesCmdLine("adb.exe shell cat C:\\storage\\appcrash.log"))))
+        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)? shell cat /storage/appcrash\\.log$"))))
         .thenReturn("crash log contents");
 
     assertEquals("crash log contents", device.getCrashLog());
@@ -76,11 +72,8 @@ public class AbstractDeviceTest {
         "1 zygote%n" +
         "23 /system/bin/mediaserver");
     when(
-        device.executeCommandQuietly(argThat(matchesCmdLine("adb shell ps"))))
-        .thenReturn(psOutput);
-    when(
-        device.executeCommandQuietly(argThat(matchesCmdLine("adb.exe shell ps"))))
-        .thenReturn(psOutput);
+        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)? shell ps$"))))
+            .thenReturn(psOutput);
     String expected = String.format(
         "PID NAME%n" +
         "11 com.example.myapp%n" +


### PR DESCRIPTION
A few tests would fail when building on a Windows machine due to the different newline character Windows uses and a file path in one test. Fixing these allows the project to build successfully on Windows without skipping tests.