### PR TITLE
Add assets for inspector

### DIFF
--- a/selendroid-server/pom.xml
+++ b/selendroid-server/pom.xml
@@ -77,6 +77,7 @@
 				<configuration>
 					<androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
 					<resourceDirectory>${project.basedir}/res</resourceDirectory>
+					<assetsDirectory>${project.basedir}/assets</assetsDirectory>
 					<outputDirectory>bin/classes</outputDirectory>
 					<testOutputDirectory>bin/test-classes</testOutputDirectory>
 					<failOnNonStandardStructure>false</failOnNonStandardStructure>


### PR DESCRIPTION
The `assets` directory contains all the JS and CSS files for the Selendroid inspector. The directory was missing in the APK since https://github.com/selendroid/selendroid/commit/7ae21137dde0b17522f08db20fb248ac0c3a9aa0.

This fixes the missing assets. 

The Selendroid inspector still crashes in JS in `onTreeLoaded`:

    this.root = this.jstree.jstree('get_json')[0];
    this.xml = this.root.metadata.xml;  // this.root is a div, metadata is undefined

I added at least some try-catch-finally error handling (this was missing) but I'm not familiar with the Inspector JS code. @DominikDary can you explain the purpose of `this.root.metadata.xml`? I don't see any recent changes to `inspector.js` or jQuery version bumps that could break this.