### PR TITLE
User sends "true" for a Boolean DesiredCapability

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
@@ -108,7 +108,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public Boolean getEmulator() {
     if (getRawCapabilities().get(EMULATOR) == null
         || getRawCapabilities().get(EMULATOR).equals(JSONObject.NULL)) return null;
-    return (Boolean) getRawCapabilities().get(EMULATOR);
+    return getBooleanCapability(EMULATOR);
   }
 
   public String getPlatformName() {
@@ -395,4 +395,17 @@ public class SelendroidCapabilities extends DesiredCapabilities {
     return listOfApps.size() > 0 ? listOfApps.last() : null;
   }
 
+  // throws exception if user didn't pass the capability as a boolean
+  private Boolean getBooleanCapability(String key) {
+    Object o = getRawCapabilities().get(key);
+    if (o == null) {
+      return null;
+    } else if (o instanceof Boolean) {
+      return (Boolean) o;
+    } else {
+      throw new ClassCastException(String.format(
+          "DesiredCapability %s's value should be boolean: found value %s of type %s", key, o.toString(), o.getClass()
+              .getName()));
+    }
+  }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -63,7 +63,7 @@ public abstract class AbstractDevice implements AndroidDevice {
   public static final String WD_STATUS_ENDPOINT = "http://localhost:8080/wd/hub/status";
   protected String serial = null;
   protected String model = null;
-  protected String apiTargetType = null;
+  protected String apiTargetType = "android";
   protected Integer port = null;
   protected IDevice device;
   private ByteArrayOutputStream logoutput;

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
@@ -102,7 +102,6 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   }
 
   private void extractAPITargetType(String avdOutput) {
-    this.apiTargetType = "android"; // default
     String target = extractValue("Target: (.*?)$", avdOutput);
     // chose to compare against both of these strings because currently some targets say google_api [Google APIs] so
     // perhaps the actual name which looks to be google_api will be the only string in the target in the future

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
@@ -35,7 +35,6 @@ public class DefaultHardwareDevice extends AbstractDevice {
 
   public DefaultHardwareDevice(IDevice device) {
     super(device);
-    this.apiTargetType = "android"; // default
     // today the only API we check for is Google APIs by looking for a maps jar which only exists if google apis are on
     // the target
     String output = runAdbCommand("shell ls /system/framework/*map*");
@@ -95,7 +94,7 @@ public class DefaultHardwareDevice extends AbstractDevice {
   @Override
   public String toString() {
     return "HardwareDevice [serial=" + serial + ", model=" + getModel() + ", targetVersion="
-        + getTargetPlatform() + "]";
+        + getTargetPlatform() + ", apiTargetType=" + apiTargetType + "]";
   }
   
   public String getSerial() {


### PR DESCRIPTION
Be more forgiving with Boolean desiredCapabilities in the case where the user sends the boolean value over as a String like "true" instead of true.