### PR TITLE
Clear data before app launch

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -234,6 +234,10 @@ public class SelendroidStandaloneDriver implements ServerDetails {
           log.info("the app under test is already installed.");
         }
 
+        if(!serverConfiguration.isNoClearData()) {
+          device.clearUserData(app);
+        }
+
         int port = getNextSelendroidServerPort();
         boolean serverInstalled = device.isInstalled("io.selendroid." + app.getBasePackage());
         if (!serverInstalled || serverConfiguration.isForceReinstall()) {


### PR DESCRIPTION
Due to various conditions (race, user interaction between test runs, etc) the app isn't always in a clean state on launch with noClearData=false. Adding a data clear before the app is launched.