### PR TITLE
implemented driver.manage().timeouts().PageLoadTimeout()

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/TimeoutsHandler.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/handler/timeouts/TimeoutsHandler.java
@@ -21,6 +21,8 @@ public class TimeoutsHandler extends SafeRequestHandler {
       getSelendroidDriver(request).setAsyncTimeout(timeout);
     } else if (type.equals("implicit")) {
       ServerInstrumentation.getInstance().setImplicitWait(timeout);
+    } else if (type.equals("page load")) {
+      getSelendroidDriver(request).setPageLoadTimeout(timeout);
     } else {
       return new SelendroidResponse(getSessionId(request),
           StatusCode.UNKNOWN_COMMAND,

--- a/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
@@ -756,6 +756,12 @@ public class DefaultSelendroidDriver implements SelendroidDriver {
     }
   }
 
+  public void setPageLoadTimeout(long timeout) {
+    if (selendroidWebDriver != null) {
+      selendroidWebDriver.setPageLoadTimeout(timeout);
+    }
+  }
+
   public boolean isAirplaneMode() {
     return Settings.System.getInt(
         ServerInstrumentation.getInstance().getCurrentActivity().getContentResolver(),

--- a/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidDriver.java
@@ -98,6 +98,8 @@ public interface SelendroidDriver {
 
   public void setAsyncTimeout(long timeout);
 
+  public void setPageLoadTimeout(long timeout);
+
   public boolean isAirplaneMode();
   
   public void roll(int dimensionX, int dimensionY);


### PR DESCRIPTION
Implemented #300 

Allows to edit the page load timeout through driver.manage().timeouts().PageLoadTimeout(long seconds, java.util.concurrent.TimeUnit unit)

Will throw a TimeoutException if the page load exceeds the timeout.