### PR TITLE
append error details to page source

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/inspector/TreeUtil.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/inspector/TreeUtil.java
@@ -51,6 +51,7 @@ public class TreeUtil {
     metadata.put("l10n", from.getJSONObject("l10n"));
     metadata.put("shown", from.getBoolean("shown"));
     metadata.put("source", from.optString("source"));
+    metadata.put("error", from.optString("error"));
 
     node.put("metadata", metadata);
     JSONObject rect = new JSONObject();

--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
@@ -361,7 +361,14 @@ public class AndroidNativeElement implements AndroidElement {
     object.put("type", getView().getClass().getSimpleName());
     String value = "";
     if (getView() instanceof TextView) {
-      value = String.valueOf(((TextView) getView()).getText());
+      TextView textView = (TextView) getView();
+      value = String.valueOf(textView.getText());
+
+      CharSequence error = textView.getError();
+      if(error != null && error.length() > 0){
+        SelendroidLogger.info("error: " + error);
+        object.put("error", error);
+      }
     }
     object.put("value", value);
     object.put("shown", getView().isShown());

--- a/selendroid-server/src/main/java/io/selendroid/server/model/internal/JsonXmlUtil.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/internal/JsonXmlUtil.java
@@ -77,6 +77,11 @@ public class JsonXmlUtil {
     node.setAttribute("id", from.optString("id"));
     node.setAttribute("shown", from.optString("shown"));
 
+    String error = from.optString("error");
+    if(error != null){
+      node.setAttribute("error", error);
+    };
+
     JSONObject rect = from.optJSONObject("rect");
     if (rect != null) {
       Element rectNode = document.createElement("rect");


### PR DESCRIPTION
Currently its not possible to get details about errors with selendroid. this change just appends the error text to the page source. 