### PR TITLE
Delete temporary created by Selendroid Server

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
@@ -140,6 +140,9 @@ public class SelendroidConfiguration {
   @Parameter(names = "-folder", description = "The folder which contains Android applications under test. This folder will monitor and add new apps to the apps store during the lifetime of the selendroid node.")
   private String folder = null;
 
+  @Parameter(names = "-deleteTmpFiles", description = "Deletes temporary files created by the Selendroid Server.")
+  private boolean deleteTmpFiles = true;
+
   public void setKeystore(String keystore) {
     this.keystore = keystore;
   }
@@ -362,6 +365,14 @@ public class SelendroidConfiguration {
 
   public String getAppFolderToMonitor() {
     return folder;
+  }
+
+  public boolean isDeleteTmpFiles() {
+    return deleteTmpFiles;
+  }
+
+  public void setDeleteTmpFiles(boolean deleteTmpFiles){
+    this.deleteTmpFiles = deleteTmpFiles;
   }
 
   /**

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/builder/SelendroidServerBuilder.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/builder/SelendroidServerBuilder.java
@@ -96,7 +96,9 @@ public class SelendroidServerBuilder {
   /* package */void init(AndroidApp aut) throws IOException, ShellCommandException {
     applicationUnderTest = aut;
     File customizedServer = File.createTempFile("selendroid-server", ".apk");
-
+    if(serverConfiguration != null && serverConfiguration.isDeleteTmpFiles()) {
+      customizedServer.deleteOnExit(); //Deletes temporary files created
+    }
     log.info("Creating customized Selendroid-server: " + customizedServer.getAbsolutePath());
     InputStream is = getResourceAsStream(selendroidPrebuildServerPath);
 
@@ -113,10 +115,12 @@ public class SelendroidServerBuilder {
     cleanUpPrebuildServer();
     File selendroidServer = createAndAddCustomizedAndroidManifestToSelendroidServer();
     File outputFile =
-        new File(FileUtils.getTempDirectory(), String.format("selendroid-server-%s-%s.apk",
+      new File(FileUtils.getTempDirectory(), String.format("selendroid-server-%s-%s.apk",
                                                              applicationUnderTest.getBasePackage(),
                                                              getJarVersionNumber()));
-
+    if(serverConfiguration != null && serverConfiguration.isDeleteTmpFiles()) {
+      outputFile.deleteOnExit(); //Deletes file when done
+    }
     return signTestServer(selendroidServer, outputFile);
   }
 
@@ -146,6 +150,9 @@ public class SelendroidServerBuilder {
     deleteFileFromAppSilently(app, "META-INF/NDKEYSTO.RSA");
 
     File outputFile = new File(appFile.getParentFile(), "resigned-" + appFile.getName());
+    if(serverConfiguration != null && serverConfiguration.isDeleteTmpFiles()) {
+      outputFile.deleteOnExit();
+    }
     return signTestServer(appFile, outputFile);
   }
 
@@ -215,6 +222,7 @@ public class SelendroidServerBuilder {
     ZipArchiveEntry binaryManifestXml = manifestApk.getEntry("AndroidManifest.xml");
 
     File finalSelendroidServerFile = new File(tempdir.getAbsolutePath() + "selendroid-server.apk");
+
     ZipArchiveOutputStream finalSelendroidServer =
         new ZipArchiveOutputStream(finalSelendroidServerFile);
     finalSelendroidServer.putArchiveEntry(binaryManifestXml);

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -164,8 +164,12 @@ public class SelendroidStandaloneDriver implements ServerDetails {
         // using "android" as the app name, because that is the desired capability default in
         // selenium for
         // DesiredCapabilities.ANDROID
+        File androidAPK = androidDriverAPKBuilder.extractAndroidDriverAPK();
+        if(serverConfiguration != null && serverConfiguration.isDeleteTmpFiles()) {
+          androidAPK.deleteOnExit(); //Deletes temporary files if flag set
+        }
         AndroidApp app =
-            selendroidApkBuilder.resignApp(androidDriverAPKBuilder.extractAndroidDriverAPK());
+            selendroidApkBuilder.resignApp(androidAPK);
         appsStore.put(BrowserType.ANDROID, app);
       } catch (Exception e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
Added a command line flag, -deleteTmpFiles, to delete temporary files that persist in the temp directory. Files were being created after Selendroid Standalone Server was started and test app was run. When server is started with flag, then files will be deleted when server is stopped.