### PR TITLE
Wake screen before running tests

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
@@ -96,4 +96,6 @@ public interface AndroidDevice {
   public String getModel();
 
   public String getAPITargetType();
+
+  public void unlockScreen() throws AndroidDeviceException;
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidEmulator.java
@@ -54,7 +54,7 @@ public interface AndroidEmulator {
 
   public void setSerial(int port);
 
-  public void unlockEmulatorScreen() throws AndroidDeviceException;
+  public void unlockScreen() throws AndroidDeviceException;
 
   public void setWasStartedBySelendroid(boolean wasStartedBySelendroid);
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
@@ -354,7 +354,7 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
 
     log.info("Emulator start took: " + (System.currentTimeMillis() - start) / 1000 + " seconds");
     log.info("Please have in mind, starting an emulator takes usually about 45 seconds.");
-    unlockEmulatorScreen();
+    unlockScreen();
 
     waitForLauncherToComplete();
 
@@ -367,7 +367,7 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
     setWasStartedBySelendroid(true);
   }
 
-  public void unlockEmulatorScreen() throws AndroidDeviceException {
+  public void unlockScreen() throws AndroidDeviceException {
     // Send menu key event
     CommandLine menuKeyCommand = getAdbCommand();
     menuKeyCommand.addArgument("shell", false);

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
@@ -22,8 +22,8 @@ import java.util.logging.Logger;
 import com.android.ddmlib.IDevice;
 import com.android.ddmlib.RawImage;
 
+import io.selendroid.standalone.exceptions.AndroidDeviceException;
 import org.openqa.selenium.Dimension;
-
 
 public class DefaultHardwareDevice extends AbstractDevice {
   private static final Logger log = Logger.getLogger(DefaultHardwareDevice.class.getName());
@@ -99,5 +99,28 @@ public class DefaultHardwareDevice extends AbstractDevice {
   
   public String getSerial() {
     return serial;
+  }
+
+  public void unlockScreen() throws AndroidDeviceException {
+    // Get phone's android version and whether screen is off or not.
+    // Different ways to detect if screen is off depending on version.
+
+    String output = runAdbCommand("shell dumpsys power");
+
+    // Lollipop and up -- API >= 20
+    if (Integer.parseInt(this.targetPlatform.getApi()) >= 20) {
+      String value = extractValue("Display Power: state=(.*?)$", output);
+      if (value.equals("OFF")) {
+        // Wake screen
+        inputKeyevent(26);
+      }
+      // Kitkat and below -- API <= 19
+    } else {
+      String value = extractValue("mScreenOn=(.*?)$", output);
+      if (value.equals("false")) {
+        // Wake screen
+        inputKeyevent(26);
+      }
+    }
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -229,6 +229,9 @@ public class SelendroidStandaloneDriver implements ServerDetails {
         // If we are using an emulator need to start it up
         if (device instanceof AndroidEmulator) {
           startAndroidEmulator(desiredCapabilities, (AndroidEmulator) device);
+          // If we are using an android device
+        } else {
+          device.unlockScreen();
         }
 
         boolean appInstalledOnDevice = device.isInstalled(app) || app instanceof InstalledAndroidApp;
@@ -284,12 +287,12 @@ public class SelendroidStandaloneDriver implements ServerDetails {
 
         // create the new session on the device server
         RemoteWebDriver driver =
-                new RemoteWebDriver(new URL("http://localhost:" + port + "/wd/hub"), desiredCapabilities);
+          new RemoteWebDriver(new URL("http://localhost:" + port + "/wd/hub"), desiredCapabilities);
         String sessionId = driver.getSessionId().toString();
         SelendroidCapabilities requiredCapabilities =
-                new SelendroidCapabilities(driver.getCapabilities().asMap());
+          new SelendroidCapabilities(driver.getCapabilities().asMap());
         ActiveSession session =
-                new ActiveSession(sessionId, requiredCapabilities, app, device, port, this);
+          new ActiveSession(sessionId, requiredCapabilities, app, device, port, this);
 
         this.sessions.put(sessionId, session);
 
@@ -347,7 +350,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
         }
       } else {
         throw new SelendroidException("Selendroid server on the device didn't come up after "
-                + startTimeout / 1000 + "sec:");
+            + startTimeout / 1000 + "sec:");
       }
     }
     log.info("Selendroid server has started.");
@@ -374,7 +377,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
   private void startAndroidEmulator(SelendroidCapabilities desiredCapabilities, AndroidEmulator device) throws AndroidDeviceException {
     AndroidEmulator emulator = device;
     if (emulator.isEmulatorStarted()) {
-      emulator.unlockEmulatorScreen();
+      emulator.unlockScreen();
     } else {
       Map<String, Object> config = new HashMap<String, Object>();
       if (serverConfiguration.getEmulatorOptions() != null) {
@@ -577,7 +580,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
         deviceInfo.put(SelendroidCapabilities.API_TARGET_TYPE,
             device.getAPITargetType());
         deviceInfo
-            .put(SelendroidCapabilities.PLATFORM_VERSION, device.getTargetPlatform().getApi());
+          .put(SelendroidCapabilities.PLATFORM_VERSION, device.getTargetPlatform().getApi());
         deviceInfo.put(SelendroidCapabilities.SCREEN_SIZE, device.getScreenSize());
 
         list.put(deviceInfo);


### PR DESCRIPTION
On Android devices, if the screen is off, tests would not run; this turns the device on before running tests.  
#752   
@mtimkovich and I worked on this.  
Should I squash the commits?