### PR TITLE
Change the getCenterCoordinates method to accept float number strings…

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidWebElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidWebElement.java
@@ -230,8 +230,9 @@ public class AndroidWebElement implements AndroidElement {
       throw new SelendroidException(e);
     }
 
-    return new Point(topLeft.x + Integer.parseInt(result[0]) / 2, topLeft.y
-        + Integer.parseInt(result[1]) / 2);
+    int xSize = (new Double(result[0])).intValue();
+    int ySize = (new Double(result[1])).intValue();
+    return new Point(topLeft.x + xSize / 2, topLeft.y+ ySize / 2);
   }
 
   @Override


### PR DESCRIPTION
… for element size. This case may happen to devices like Nexus 5/9

I created this pull request based on our discussion. 
https://github.com/selendroid/selendroid/issues/865
