### PR TITLE
Move DecorViewPredicate to own class and add to PredicateFactory

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/android/ViewHierarchyAnalyzer.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/android/ViewHierarchyAnalyzer.java
@@ -13,6 +13,7 @@
  */
 package io.selendroid.server.android;
 
+import io.selendroid.server.model.Factories;
 import io.selendroid.server.ServerInstrumentation;
 import io.selendroid.server.util.InstanceOfPredicate;
 import io.selendroid.server.util.ListUtil;
@@ -93,8 +94,11 @@ public class ViewHierarchyAnalyzer {
   }
 
   private View getRecentDecorView(Set<View> views) {
+    Predicate<Object> decorViewPredicate =
+      Factories.getPredicatesFactory().createDecorViewPredicate();
     Collection<View> decorViews =
-        (Collection<View>) ListUtil.filter(new ArrayList<View>(views), new DecorViewPredicate());
+      (Collection<View>) ListUtil.filter(new ArrayList<View>(views), decorViewPredicate);
+
     if (decorViews.isEmpty()) {
         SelendroidLogger.warning("In class ViewHierarchyAnalyzer, no top level decor views!");
         SelendroidLogger.warning("Top level views:");
@@ -102,6 +106,7 @@ public class ViewHierarchyAnalyzer {
             SelendroidLogger.warning(view.toString());
         }
     }
+
     View container = null;
     // candidate is to fall back to most recent 'shown' view if none have the 'window focus'
     // this seems to be able to happen with menus
@@ -123,17 +128,6 @@ public class ViewHierarchyAnalyzer {
       container = candidate;
     }
     return container;
-  }
-
-  private static class DecorViewPredicate<E> implements Predicate<E> {
-    @Override
-    public boolean apply(E view) {
-      // PopupViewContainer can be a top level menu shown
-      // MultiPhoneDecorView is for Samsung devices
-      return "DecorView".equals(view.getClass().getSimpleName())
-          || "PopupViewContainer".equals(view.getClass().getSimpleName())
-          || "MultiPhoneDecorView".equals(view.getClass().getSimpleName());
-    }
   }
 
   public Collection<View> getViews(List<View> rootViews) {

--- a/selendroid-server/src/main/java/io/selendroid/server/model/DecorViewPredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/DecorViewPredicate.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.server.model;
+
+import android.view.View;
+import com.android.internal.util.Predicate;
+
+public class DecorViewPredicate implements Predicate<Object> {
+  @Override
+  public boolean apply(Object view) {
+    // PopupViewContainer can be a top level menu shown
+    // MultiPhoneDecorView is for Samsung devices
+    String viewSimpleClassName = view.getClass().getSimpleName();
+    return viewSimpleClassName.equals("DecorView")
+      || viewSimpleClassName.equals("PopupViewContainer")
+      || viewSimpleClassName.equals("MultiPhoneDecorView");
+  }
+}

--- a/selendroid-server/src/main/java/io/selendroid/server/model/PredicatesFactory.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/PredicatesFactory.java
@@ -42,4 +42,8 @@ public class PredicatesFactory {
   public Predicate<View> createClassPredicate(String using) {
     return new ClassPredicate(using);
   }
+
+  public Predicate<Object> createDecorViewPredicate() {
+    return new DecorViewPredicate();
+  }
 }


### PR DESCRIPTION
Simply moved DecorViewPredicate into its own file and adds it to the PredicateFactory.

Test plan:
mvn clean compile package