### PR TITLE
Default implicit wait time should be 0 as per spec

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/android/AndroidWait.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/android/AndroidWait.java
@@ -29,7 +29,7 @@ import io.selendroid.server.util.Function;
  */
 public class AndroidWait implements Wait<Void> {
   public static final long DEFAULT_SLEEP_INTERVAL = 200;
-  private static final long DEFAULT_TIMEOUT = 5000;
+  private static final long DEFAULT_TIMEOUT = 0;
 
   private final Clock clock;
   private final long sleepIntervalInMillis;


### PR DESCRIPTION
The w3c webdriver spec states that the implicit wait timeout should be
zero milliseconds unless stated otherwise:

> A session has an associated session implicit wait timeout that
> specifies a time to wait for the implicit element location strategy
> when locating elements using find element and find elements. Unless
> stated otherwise it is zero milliseconds.
- https://w3c.github.io/webdriver/webdriver-spec.html

Selendroid had an implicit wait timeout of 5 seconds. The timeout leads
to unexpected behavior in the case of elements that are not present in
the view hierarchy. If a test wants to assert that an element is not
present in the current view it will always take 5 seconds to get a
response.

The old behavior can be re-enabled by calling:

```
driver
  .manage()
  .timeouts()
  .implicitlyWait(5, TimeUnit.SECONDS);
```