### PR TITLE
Various fixes

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -20,7 +20,6 @@ import com.android.ddmlib.TimeoutException;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.ObjectArrays;
-
 import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.server.common.exceptions.SelendroidException;
 import io.selendroid.server.common.model.ExternalStorageFile;
@@ -31,7 +30,6 @@ import io.selendroid.standalone.exceptions.AndroidDeviceException;
 import io.selendroid.standalone.exceptions.AndroidSdkException;
 import io.selendroid.standalone.exceptions.ShellCommandException;
 import io.selendroid.standalone.io.ShellCommand;
-
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecuteResultHandler;
 import org.apache.commons.exec.DefaultExecutor;
@@ -47,10 +45,8 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.logging.LogEntry;
 
 import javax.imageio.ImageIO;
-
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
@@ -457,15 +453,14 @@ public abstract class AbstractDevice implements AndroidDevice {
     if (rawImage == null) return null;
 
     BufferedImage image =
-        new BufferedImage(rawImage.width, rawImage.height, BufferedImage.TYPE_INT_ARGB);
+        new BufferedImage(rawImage.width, rawImage.height, BufferedImage.TYPE_3BYTE_BGR);
 
     int index = 0;
     int IndexInc = rawImage.bpp >> 3;
     for (int y = 0; y < rawImage.height; y++) {
       for (int x = 0; x < rawImage.width; x++) {
-        int value = rawImage.getARGB(index);
+        image.setRGB(x, y, rawImage.getARGB(index));
         index += IndexInc;
-        image.setRGB(x, y, value);
       }
     }
     ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
@@ -56,6 +56,7 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
       .put("WVGA800", new Dimension(480, 800))
       .put("WVGA854", new Dimension(480, 854))
       .put("WXGA", new Dimension(1280, 800))
+      .put("WXGA720", new Dimension(1280, 720))
       .put("WXGA800", new Dimension(1280, 800))
       .build();
 


### PR DESCRIPTION
- Add WXGA720 skin for detection of screen resolution.
- Optimize screenshots from standalone server - use 3 bytes per pixel instead of 4 bytes. Produces 25% smaller BufferedImage object.
- Fix bug SelendroidServerBuilder when executing tests and using default keystore alias and passwords and androidKeyStore file exists - initialize fields with default values.