### PR TITLE
[test-app] Simplify surefire test configuration

### DIFF
--- a/selendroid-test-app/pom.xml
+++ b/selendroid-test-app/pom.xml
@@ -152,22 +152,13 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.16</version>
-				<executions>
-					<execution>
-						<id>integration-tests</id>
-						<phase>integration-test</phase>
-						<goals>
-							<goal>test</goal>
-						</goals>
-						<configuration>
-							<skipTests>${skipTests}</skipTests>
-							<includes>
-								<include>**/*Tests.java</include>
-								<include>**/*Test.java</include>
-							</includes>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<skipTests>${skipTests}</skipTests>
+					<includes>
+						<include>**/*Tests.java</include>
+						<include>**/*Test.java</include>
+					</includes>
+				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.apache.maven.surefire</groupId>


### PR DESCRIPTION
The test-app tests are still disabled by default. It occured to me that
not all tests were running. Removing the `executions` part of the
`pom.xml` file made the `includes` part of the surefire configuration
work.