### PR TITLE
[client] Fix SelendroidDriver#readCallLog()

### DIFF
--- a/selendroid-client/src/main/java/io/selendroid/client/SelendroidDriver.java
+++ b/selendroid-client/src/main/java/io/selendroid/client/SelendroidDriver.java
@@ -235,19 +235,18 @@ public class SelendroidDriver extends RemoteWebDriver
   }
 
   public List<CallLogEntry> readCallLog() {
-        
-    String callLogString = null;  
+    Response response = execute("readCallLog");
+    Object value = response.getValue();
     try {
-        callLogString = (String)execute("readCallLog").getValue();
-        JSONArray json = new JSONArray(callLogString);
-        List<CallLogEntry> logEntries = new ArrayList<CallLogEntry>(json.length());
-        for(int i=0; i < json.length(); i++) {
-            logEntries.add(CallLogEntry.fromJson(json.getString(i)));
-        }
-        return logEntries;
-    }
-    catch(JSONException e) {
-        throw new IllegalStateException("Unable to parse CallLogEntry from json " + callLogString);
+      List<String> returnedLogs = (List<String>) value;
+      List<CallLogEntry> logEntries = new ArrayList<CallLogEntry>(returnedLogs.size());
+      for (String jsonLogEntry : returnedLogs) {
+          logEntries.add(CallLogEntry.fromJson(jsonLogEntry));
+      }
+      return logEntries;
+    } catch (ClassCastException ex) {
+      throw new WebDriverException("Returned value cannot be converted to List<String>: " + value,
+              ex);
     }
   }
 


### PR DESCRIPTION
AddCallLogTest was broken. Turns out the `readCallLog()` method was
actually broken. The `execute()` method returns an `ArrayList<String>`,
so the cast to `String` was erroring.

Changed the cast to the appriopriate one and fixed the loop that parses
the individual call log entries. Added extra error handling for the
class cast exception.