### PR TITLE
[server] Fix ClassPredicate

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/ClassPredicate.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/ClassPredicate.java
@@ -16,6 +16,7 @@ package io.selendroid.server.model;
 import android.view.View;
 import com.android.internal.util.Predicate;
 import io.selendroid.server.common.exceptions.NoSuchElementException;
+import io.selendroid.server.util.SelendroidLogger;
 
 public class ClassPredicate implements Predicate<View> {
 
@@ -30,7 +31,8 @@ public class ClassPredicate implements Predicate<View> {
     try {
       return Class.forName(using).isInstance(to);
     } catch (ClassNotFoundException e) {
-      throw new NoSuchElementException("The view class '" + using + "' was not found.");
+      SelendroidLogger.warning("Finding by unknown class " + using);
+      return false;
     }
   }
 }

--- a/selendroid-test-app/src/test/java/io/selendroid/nativetests/NativeChildElementFindingTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/nativetests/NativeChildElementFindingTest.java
@@ -33,7 +33,7 @@ public class NativeChildElementFindingTest extends BaseAndroidTest {
   public static final String ACTIVITY_CLASS = "io.testapp." + "HomeScreenActivity";
 
   private void assertListIsEmpty(List<WebElement> elements) {
-    Assert.assertTrue("Expecting empty list when no elements are found.",elements.isEmpty());
+    Assert.assertTrue("Expecting empty list when no elements are found.", elements.isEmpty());
   }
 
 
@@ -177,7 +177,7 @@ public class NativeChildElementFindingTest extends BaseAndroidTest {
     openStartActivity();
     WebElement rootElement = driver().findElement(By.id("l10n"));
     try {
-      rootElement.findElement(By.className("de.dary.MyView"));
+      rootElement.findElement(By.className("io.selendroid.testapp.view.FingerView"));
       Assert.fail("Should not have succeeded");
     } catch (NoSuchElementException e) {
       // this is expected
@@ -186,6 +186,25 @@ public class NativeChildElementFindingTest extends BaseAndroidTest {
 
   @Test()
   public void shouldNotFindChildElementsByClass() {
+    openStartActivity();
+    WebElement rootElement = driver().findElement(By.id("l10n"));
+    assertListIsEmpty(rootElement.findElements(By.className("io.selendroid.testapp.view.FingerView")));
+  }
+
+  @Test()
+  public void shouldNotFindChildElementByClassThatDoesNotExist() {
+    openStartActivity();
+    WebElement rootElement = driver().findElement(By.id("l10n"));
+    try {
+      rootElement.findElement(By.className("de.dary.MyView"));
+      Assert.fail("Should not have succeeded");
+    } catch (NoSuchElementException e) {
+      // this is expected
+    }
+  }
+
+  @Test()
+  public void shouldNotFindChildElementsByClassThatDoesNotExist() {
     openStartActivity();
     WebElement rootElement = driver().findElement(By.id("l10n"));
     assertListIsEmpty(rootElement.findElements(By.className("de.dary.MyView")));


### PR DESCRIPTION
While looking into the failures of `NativeChildElementFindingTest` I
found out that the `ClassPredicate` is throwing an exception in case the
class is not found in the app. This regressed in
4afa5ccedc53b0b73319dfe3a6917db0f557fddc when the class predicate was
extracted to its own class.

I changed the class predicate to return false if the class is not found,
but logging a warning for discoverability. I changed the tests to use an
existing class in the normal case and added new tests to guard for the
appropriate behavior if the class does not exist.