### PR TITLE
[test-app] Unbreak SendKeyAndNativeKeyTest

### DIFF
--- a/selendroid-test-app/src/test/java/io/selendroid/nativetests/SendKeyAndNativeKeyTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/nativetests/SendKeyAndNativeKeyTest.java
@@ -18,6 +18,7 @@ import io.selendroid.client.waiter.WaitingConditions;
 import io.selendroid.support.BaseAndroidTest;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
@@ -26,6 +27,7 @@ import static io.selendroid.client.waiter.TestWaiter.waitFor;
 
 public class SendKeyAndNativeKeyTest extends BaseAndroidTest {
   @Test
+  @Ignore("Test is flaky. Ends up sending keys too early, etc.")
   public void shouldTriggerNativeSearch() throws Exception {
     openStartActivity();
 


### PR DESCRIPTION
The test will sometimes pass, but most of the times it will enter a
weird black screen with no search results. It seems to be because the
input manager is rejecting input events from time to time.