### PR TITLE
[test-app] Set log level to DEBUG for tests

### DIFF
--- a/selendroid-test-app/src/test/java/io/selendroid/support/BaseAndroidTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/support/BaseAndroidTest.java
@@ -18,6 +18,7 @@ import io.selendroid.client.waiter.WaitingConditions;
 import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.standalone.SelendroidConfiguration;
 import io.selendroid.standalone.SelendroidLauncher;
+import io.selendroid.standalone.log.LogLevelEnum;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -115,6 +116,7 @@ public class BaseAndroidTest {
 
   @BeforeClass
   public static void startSelendroidServer() throws Exception {
+    conf.setLogLevel(LogLevelEnum.DEBUG);
     launcher.launchSelendroid();
   }
 


### PR DESCRIPTION
When debugging what's going on with tests it's very useful to have the
debug output of the selendroid server on the emulator.