### PR TITLE
[standalone] Fix GetLogTypes handler

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/GetLogTypes.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/GetLogTypes.java
@@ -30,6 +30,8 @@ public class GetLogTypes extends BaseSelendroidStandaloneHandler {
 
   @Override
   public Response handleRequest(HttpRequest request, JSONObject payload) throws JSONException {
-    return new SelendroidResponse(getSessionId(request), new JSONArray("logcat"));
+    JSONArray responseValue = new JSONArray();
+    responseValue.put("logcat");
+    return new SelendroidResponse(getSessionId(request), responseValue);
   }
 }


### PR DESCRIPTION
Summary: The constructor of `JSONArray` that takes a string assumes that
the string is a JSON document. In the handler we want to construct a new
JSONArray to serialize it.

Test Plan:
Start selendroid-standalone and curl the `.../log/types` endpoint.
```
$ java -jar selendroid-standalone/target/selendroid-standalone-0.16.0-SNAPSHOT-with-dependencies.jar
$ $ curl -v localhost:4444/wd/hub/session/id/log/types
...
{"status":0,"sessionId":"id","value":["logcat"]}
```