### PR TITLE
[standalone] Fix HTTP response for unknown commands

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/ProxyToDeviceHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/ProxyToDeviceHandler.java
@@ -83,6 +83,9 @@ public class ProxyToDeviceHandler extends BaseSelendroidStandaloneHandler {
     while (retries-- > 0) {
       try {
         response = proxyRequestToDevice(request, session, url, method);
+        if (response == null) { // Unknown command
+          return new SelendroidResponse(sessionId, StatusCode.UNKNOWN_COMMAND);
+        }
         break;
       } catch (Exception e) {
         if (retries == 0) {
@@ -170,6 +173,9 @@ public class ProxyToDeviceHandler extends BaseSelendroidStandaloneHandler {
       r = HttpClientUtil.executeRequest(url, HttpMethod.DELETE);
     } else {
       throw new SelendroidException("HTTP method not supported: " + method);
+    }
+    if (r.getStatusLine().getStatusCode() == 404) { // Unknown command
+      return null;
     }
     return HttpClientUtil.parseJsonResponse(r);
   }


### PR DESCRIPTION
Summary: Before this fix the selendroid standalone server would proxy
any command to the server on the device. The server on the device would
return `404 Not Found`. The standalone server then failed to deserialize
that string as JSON and actually ended up retrying proxying the command
to the device three times.

Test Plan: Create a new session and try to query existing and
non-existing endpoints:

```
$ curl localhost:4444/wd/hub/session/8fbdf5e5-bc39-7012-09f8-0417acdf6916/foo
{"status":0,"sessionId":"8fbdf5e5-bc39-7012-09f8-0417acdf6916","value":"UNKNOWN_COMMAND"}
$ curl localhost:4444/wd/hub/session/8fbdf5e5-bc39-7012-09f8-0417acdf6916/
{"status":0,"sessionId":"8fbdf5e5-bc39-7012-09f8-0417acdf6916",...}
$ curl -XPOST localhost:4444/wd/hub/session/8fbdf5e5-bc39-7012-09f8-0417acdf6916/log
{"status":0,"sessionId":"8fbdf5e5-bc39-7012-09f8-0417acdf6916","value":["[2015-0...}
```