### PR TITLE
[server] Fix NPE in ViewHierarchyAnalyzer

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/android/ViewHierarchyAnalyzer.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/android/ViewHierarchyAnalyzer.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import android.app.Activity;
 import android.content.res.Resources;
 import android.view.View;
 import android.view.ViewGroup;
@@ -160,12 +161,20 @@ public class ViewHierarchyAnalyzer {
   public static String getNativeId(View view) {
     String id = "";
     try {
+      Activity currentActivity = ServerInstrumentation.getInstance().getCurrentActivity();
 
-      id =
-          ServerInstrumentation.getInstance().getCurrentActivity().getResources()
-              .getResourceName(view.getId());
-      // remove the package name
-      id = id.substring(id.indexOf(':') + 1);
+      Resources resources;
+      if (currentActivity != null) {
+        resources =  currentActivity.getResources();
+      } else {
+        resources = view.getResources();
+      }
+      if (resources != null) {
+        id = resources.getResourceName(view.getId());
+
+        // remove the package name
+        id = id.substring(id.indexOf(':') + 1);
+      }
     } catch (Resources.NotFoundException e) {
       // can happen
     }


### PR DESCRIPTION
Summary: We are seeing cases where we're querying native elements, but
there is no current activity. Previously this would result in a
`NullPointerException` in the `ViewHierarchyAnalyzer`. This changes
fixes the exception and adds a fallback when looking for resources:

- added a check to see if the activity is `null`
- if that's the case, try to get the resources from the passed view
- before getting trying to get the resource name, check if the resources
  returned are non null (we've seen that case as well)

Test Plan: Ran our internal e2e tests against selendroid with this
patch.