### PR TITLE
[server] Do not try to get the resource name if the view has no id

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/android/ViewHierarchyAnalyzer.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/android/ViewHierarchyAnalyzer.java
@@ -158,6 +158,9 @@ public class ViewHierarchyAnalyzer {
   }
 
   public static String getNativeId(View view) {
+    if (view == null || view.getId() == View.NO_ID) {
+        return "";
+    }
     String id = "";
     try {
 


### PR DESCRIPTION
Summary: Previously selendroid would always try to look up the name of
the resource belonging to the id of the view. In some cases the view
value would actually be `View.NO_ID`. When trying to get the resource
name for `View.NO_ID` android will log a line like tho following to
logcat:

```
W/ResourceType(25943): No known package when getting name for resource number 0xffffffff
```

This change adds a check for `View.NO_ID`, making selendroid spam a lot
less.

Test Plan: Ran our internal e2e tests against selendroid with this
patch.