### PR TITLE
[server] Do not search in multiple top level views

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/DefaultSelendroidDriver.java
@@ -438,6 +438,11 @@ public class DefaultSelendroidDriver implements SelendroidDriver {
     }
 
     @Override
+    protected View getSearchRoot() {
+      return viewAnalyzer.getRecentDecorView();
+    }
+
+    @Override
     protected List<View> getTopLevelViews() {
       List<View> views = new ArrayList<View>();
       views.addAll(viewAnalyzer.getTopLevelViews());

--- a/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/internal/AbstractNativeElementContext.java
@@ -252,30 +252,27 @@ public abstract class AbstractNativeElementContext
   }
 
   /** visible for testing */
-  protected static List<AndroidElement> searchViews(AbstractNativeElementContext context, List<View> roots,
-      Predicate predicate, boolean findJustOne) {
+  protected static List<AndroidElement> searchViews(AbstractNativeElementContext context, View root,
+                                                    Predicate predicate, boolean findJustOne) {
     List<AndroidElement> elements = new ArrayList<AndroidElement>();
-    if (roots == null || roots.isEmpty()) {
+    if (root == null) {
       return elements;
     }
     ArrayDeque<View> queue = new ArrayDeque<View>();
-
-    for (View root : roots) {
-      queue.add(root);
-      while (!queue.isEmpty()) {
-        View view = queue.pop();
-        if (predicate.apply(view)) {
-          elements.add(context.newAndroidElement(view));
-          if (findJustOne) {
-            break;
-          }
+    queue.add(root);
+    while (!queue.isEmpty()) {
+      View view = queue.pop();
+      if (predicate.apply(view)) {
+        elements.add(context.newAndroidElement(view));
+        if (findJustOne) {
+          break;
         }
-        if (view instanceof ViewGroup) {
-          ViewGroup group = (ViewGroup) view;
-          int childrenCount = group.getChildCount();
-          for (int index = 0; index < childrenCount; index++) {
-            queue.add(group.getChildAt(index));
-          }
+      }
+      if (view instanceof ViewGroup) {
+        ViewGroup group = (ViewGroup) view;
+        int childrenCount = group.getChildCount();
+        for (int index = 0; index < childrenCount; index++) {
+          queue.add(group.getChildAt(index));
         }
       }
     }
@@ -283,11 +280,11 @@ public abstract class AbstractNativeElementContext
   }
 
   private List<AndroidElement> findAllByPredicate(Predicate predicate) {
-     return searchViews(this, getTopLevelViews(), predicate, false);
+     return searchViews(this, getSearchRoot(), predicate, false);
   }
 
   private AndroidElement findFirstByPredicate(Predicate predicate) {
-    List<AndroidElement> list = searchViews(this, getTopLevelViews(), predicate, true);
+    List<AndroidElement> list = searchViews(this, getSearchRoot(), predicate, true);
     if (list != null && !list.isEmpty()) {
       return list.get(0);
     }
@@ -354,6 +351,18 @@ public abstract class AbstractNativeElementContext
     }
 
     return filtered;
+  }
+
+  protected View getSearchRoot() {
+    return getTopLevelView();
+  }
+
+  protected View getTopLevelView() {
+    List<View> topLevelViews = getTopLevelViews();
+    if (topLevelViews == null || topLevelViews.isEmpty()) {
+      return null;
+    }
+    return getTopLevelViews().get(0);
   }
 
   protected abstract View getRootView();

--- a/selendroid-server/src/test/java/io/selendroid/server/model/internal/AbstractNativeElementContextTest.java
+++ b/selendroid-server/src/test/java/io/selendroid/server/model/internal/AbstractNativeElementContextTest.java
@@ -31,6 +31,7 @@ public class AbstractNativeElementContextTest {
      *   / \
      *  b   c
      */
+    @Test
     public void itFindsNothingIfNoNodeMatches() {
         ViewGroup b = ignore();
         ViewGroup c = ignore();
@@ -82,87 +83,6 @@ public class AbstractNativeElementContextTest {
         assertFoundViews(views, C, D, F);
     }
 
-    /**
-     * Currently selendroid searches all top levels views, ordered by the one
-     * that was last painted first. If this happens we should first return
-     * all the matching children from the first (visible?) tree, then from the
-     * second one, and so on.
-     *
-     *           a                       g
-     *        /     \                 /     \
-     *       b       c              h        I (3)
-     *    /     \      \         /     \      \
-     *   D(1)    e      F (2)   J(4)    k      L (5)
-     */
-    @Test
-    public void itReturnsTheChildrenInTheOrderOfTheRoots() {
-        // Bottom 1
-        ViewGroup D = match();
-        ViewGroup e = ignore();
-        ViewGroup F = match();
-
-        // Middle 1
-        ViewGroup b = ignore(D, e);
-        ViewGroup c = ignore(F);
-
-        // Root 1
-        ViewGroup root1 = ignore(b, c);
-
-        // Bottom 2
-        ViewGroup J = match();
-        ViewGroup k = ignore();
-        ViewGroup L = match();
-
-        // Middle 2
-        ViewGroup h = ignore(J, k);
-        ViewGroup I = match(L);
-
-        // Root 2
-        ViewGroup root2 = ignore(h, I);
-
-        List<View> views = searchViews(root1, root2);
-        assertFoundViews(views, D, F, I, J, L);
-    }
-
-    /**
-     * The first hierarchy has no match, but the second one has.
-     *
-     *           a                       g
-     *        /     \                 /     \
-     *       b       c              h        I (1)
-     *    /     \      \         /     \      \
-     *   d       e      F       J(2)    k      L (3)
-     */
-    @Test
-    public void itReturnsChildrenFromTheSecondRoot() {
-        // Bottom 1
-        ViewGroup d = ignore();
-        ViewGroup e = ignore();
-        ViewGroup f = ignore();
-
-        // Middle 1
-        ViewGroup b = ignore(d, e);
-        ViewGroup c = ignore(f);
-
-        // Root 1
-        ViewGroup root1 = ignore(b, c);
-
-        // Bottom 2
-        ViewGroup J = match();
-        ViewGroup k = ignore();
-        ViewGroup L = match();
-
-        // Middle 2
-        ViewGroup h = ignore(J, k);
-        ViewGroup I = match(L);
-
-        // Root 2
-        ViewGroup root2 = ignore(h, I);
-
-        List<View> views = searchViews(root1, root2);
-        assertFoundViews(views, I, J, L);
-    }
-
     private static void assertFoundViews(List<View> foundViews, View ...expectedViewsInOrder) {
         assertEquals(expectedViewsInOrder.length, foundViews.size());
 
@@ -188,14 +108,12 @@ public class AbstractNativeElementContextTest {
     /**
      * Helper to do the actual searching.
      */
-    private static List<View> searchViews(View ...roots) {
-        List<View> rootViews = new ArrayList<View>(Arrays.asList(roots));
+    private static List<View> searchViews(View root) {
         List<AndroidElement> elements = AbstractNativeElementContext.searchViews(
-                mockContext(),
-                rootViews,
-                FIND_MATCH,
-                false);
-
+                    mockContext(),
+                    root,
+                    FIND_MATCH,
+                    false);
         List<View> foundViews = new ArrayList<View>();
         for (AndroidElement element : elements) {
             foundViews.add(((AndroidNativeElement) element).getView());


### PR DESCRIPTION
Summary: In some cases selendroid ended up looking for elements in
multiple top level views. This resulted in cases where we would look up
an element by id, but the element was present in in a top level view
that was not a child of the current root view. The server happily
returns the element, but as soon as you try to interact with the
element, the known elements cache will check if the element is part of
the root level view and if that's not the case throw a
`StaleElementReference` without further information.

Instead of this confusing behavior, selendroid should search only in the
current top level view.

Test Plan:
- Ran our internal e2e tests against selendroid with this patch.
- unit tests