### PR TITLE
add more node capability for grid auto-register

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/grid/SelfRegisteringRemote.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/grid/SelfRegisteringRemote.java
@@ -115,12 +115,7 @@ public class SelfRegisteringRemote {
   }
 
   private JSONObject getDeviceConfig(final JSONObject device, final JSONObject supportedApp) throws JSONException {
-    JSONObject capa = new JSONObject();
-    capa.put(SelendroidCapabilities.SCREEN_SIZE,
-            device.getString(SelendroidCapabilities.SCREEN_SIZE));
-    String version = device.getString(SelendroidCapabilities.PLATFORM_VERSION);
-    capa.put(SelendroidCapabilities.PLATFORM_VERSION, version);
-    capa.put(SelendroidCapabilities.EMULATOR, device.getString(SelendroidCapabilities.EMULATOR));
+    JSONObject capa = new JSONObject(device, JSONObject.getNames(device));
     // For each device, register as "android" for WebView tests and also selendroid if an aut is specified
     if (ANDROIDDRIVER_APP.equals(supportedApp.get(APP_BASE_PACKAGE))) {
       //it's possible the user does not want to register the device as capable to recieve webview tests
@@ -133,7 +128,7 @@ public class SelfRegisteringRemote {
     }
     capa.put(CapabilityType.PLATFORM, "ANDROID");
     capa.put(SelendroidCapabilities.PLATFORM_NAME, "android");
-    capa.put(CapabilityType.VERSION, version);
+    capa.put(CapabilityType.VERSION, device.getString(SelendroidCapabilities.PLATFORM_VERSION));
     capa.put("maxInstances", config.getMaxInstances());
     return capa;
   }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -574,7 +574,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
           deviceInfo.put("avdName", ((DefaultAndroidEmulator) device).getAvdName());
         } else {
           deviceInfo.put(SelendroidCapabilities.EMULATOR, false);
-          deviceInfo.put("model", ((DefaultHardwareDevice) device).getModel());
+          deviceInfo.put(SelendroidCapabilities.MODEL, ((DefaultHardwareDevice) device).getModel());
           deviceInfo.put(SelendroidCapabilities.SERIAL,((DefaultHardwareDevice) device).getSerial());
         }
         deviceInfo.put(SelendroidCapabilities.API_TARGET_TYPE,


### PR DESCRIPTION
This pull request adds capabilities, such as `serial`, `model`, `platformVersion` for grid auto-register with collecting device config.
