### PR TITLE
modify regular expression to find platform folder for preview version

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidSdk.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidSdk.java
@@ -128,7 +128,7 @@ public class AndroidSdk {
     public boolean accept(File pathname) {
       String fileName = pathname.getName();
 
-      String regex = "\\d{2}\\.\\d{1}\\.\\d{1}";
+      String regex = "\\d{2}\\.\\d{1}\\.\\d{1}(?:-preview)?";
       if (fileName.matches(regex) || fileName.startsWith(ANDROID_FOLDER_PREFIX)) {
         return true;
       }


### PR DESCRIPTION
Currently build tool for Android M preview is available and this cause the error `Command 'aapt' was not found inside the Android SDK. Please update to the latest development tools and try again.`.
This pull request evade this error.