### PR TITLE
WebView needs to proxy WebViewClient & WebChromeClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<platform.version>2.3.3</platform.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<selenium.version>2.45.0</selenium.version>
+		<selenium.version>2.48.0</selenium.version>
 		<apache-httpclient.version>4.3.4</apache-httpclient.version>
 	</properties>
 	<url>http://selendroid.io</url>

--- a/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
@@ -380,15 +380,7 @@ public class SelendroidWebDriver {
             SelendroidLogger.info("Other WebView type, using SelendroidWebChromeClient");
             // get the existing WebChromeClient
             try {
-              Field f = view.getClass().getDeclaredField("mProvider");
-              f.setAccessible(true);
-              Object webViewProvider = f.get(view);
-              f = webViewProvider.getClass().getDeclaredField("mContentsClientAdapter");
-              f.setAccessible(true);
-              Object contentsClientAdapter = f.get(webViewProvider);
-              f = contentsClientAdapter.getClass().getDeclaredField("mWebChromeClient");
-              f.setAccessible(true);
-              Object webChromeClient = f.get(contentsClientAdapter);
+              Object webChromeClient = getWebClientViaReflection(view, "mWebChromeClient");
               if (webChromeClient != null) {
                 SelendroidLogger.info("webChromeClient is something! proxying it");
                 chromeClient = new WrappedChromeClient((WebChromeClient) webChromeClient);
@@ -407,15 +399,7 @@ public class SelendroidWebDriver {
           view.setWebChromeClient(chromeClient);
           // set handlers to indicate whether a page has started/done loading
           try {
-            Field f = view.getClass().getDeclaredField("mProvider");
-            f.setAccessible(true);
-            Object webViewProvider = f.get(view);
-            f = webViewProvider.getClass().getDeclaredField("mContentsClientAdapter");
-            f.setAccessible(true);
-            Object contentsClientAdapter = f.get(webViewProvider);
-            f = contentsClientAdapter.getClass().getDeclaredField("mWebViewClient");
-            f.setAccessible(true);
-            Object webViewClient = f.get(contentsClientAdapter);
+            Object webViewClient = getWebClientViaReflection(view, "mWebViewClient");
             if (webViewClient != null) {
               view.setWebViewClient(new WrappingSelendroidWebClient((WebViewClient) webViewClient));
             } else {
@@ -452,6 +436,19 @@ public class SelendroidWebDriver {
         }
       }
     });
+  }
+
+  private Object getWebClientViaReflection(WebView view, String clientField) throws NoSuchFieldException, IllegalAccessException {
+    Field f = view.getClass().getDeclaredField("mProvider");
+    f.setAccessible(true);
+    Object webViewProvider = f.get(view);
+    f = webViewProvider.getClass().getDeclaredField("mContentsClientAdapter");
+    f.setAccessible(true);
+    Object contentsClientAdapter = f.get(webViewProvider);
+    f = contentsClientAdapter.getClass().getDeclaredField(clientField);
+    f.setAccessible(true);
+    return f.get(contentsClientAdapter);
+
   }
 
   private String getWindowString() {

--- a/selendroid-test-app/res/layout/webview.xml
+++ b/selendroid-test-app/res/layout/webview.xml
@@ -19,6 +19,15 @@
     </TableRow>
 
     <TableRow
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal" >
+        <TextView
+            android:id="@+id/webviewLocation"
+            android:text="WebView location"/>
+    </TableRow>
+
+    <TableRow
         android:id="@+id/tableRowButtons"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" >

--- a/selendroid-test-app/src/main/java/io/selendroid/testapp/WebViewActivity.java
+++ b/selendroid-test-app/src/main/java/io/selendroid/testapp/WebViewActivity.java
@@ -21,12 +21,14 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
+import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
+import android.widget.TextView;
 
 public class WebViewActivity extends Activity {
   private HttpServer server = null;
@@ -42,7 +44,7 @@ public class WebViewActivity extends Activity {
     setContentView(io.selendroid.testapp.R.layout.webview);
 
     mainWebView = (WebView) findViewById(io.selendroid.testapp.R.id.mainWebView);
-    mainWebView.setWebViewClient(new WebViewClient());
+    mainWebView.setWebViewClient(new TestAppWebViewClient());
     testDataSpinner =
         (Spinner) findViewById(io.selendroid.testapp.R.id.spinner_webdriver_test_data);
     arrayAdapter =
@@ -89,6 +91,15 @@ public class WebViewActivity extends Activity {
       }
     });
     super.onCreate(savedInstanceState);
+  }
+
+  private class TestAppWebViewClient extends WebViewClient {
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+      ((TextView)findViewById(R.id.webviewLocation)).setText(url);
+      return super.shouldOverrideUrlLoading(view, url);
+    }
   }
 
   @Override

--- a/selendroid-test-app/src/test/java/io/selendroid/webviewdrivertests/WebElementInteractionTest.java
+++ b/selendroid-test-app/src/test/java/io/selendroid/webviewdrivertests/WebElementInteractionTest.java
@@ -47,6 +47,14 @@ public class WebElementInteractionTest extends BaseAndroidTest {
   }
 
   @Test
+  public void canClickOnLinkThatChangesUrlWithWebViewThatListensToShouldOverrideUrlLoading() {
+    openWebdriverTestPage(HtmlTestData.TEST_CLICK_PAGE_1);
+    driver().findElement(By.tagName("a")).click();
+    driver().context(NATIVE_APP);
+    Assert.assertEquals("file:///android_asset/web/test_click_page2.html", driver().findElement(By.id("webviewLocation")).getText());
+  }
+
+  @Test
   public void shouldGetAttributeOfTextField() {
     openWebdriverTestPage(HtmlTestData.FORM_PAGE);
     WebElement button = driver().findElement(By.cssSelector("input[id='inputWithText']"));


### PR DESCRIPTION
If the AUT is setting their own custom WebViewClient or WebChromeClient, we need to wrap it and call the AUT's object instead of overriding it.

See commit message and code comments for more info.