### PR TITLE
Hide android text select handle

### DIFF
--- a/android-driver/res/drawable-nodpi/text_select_handle.xml
+++ b/android-driver/res/drawable-nodpi/text_select_handle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <size
+            android:height="0dp"
+            android:width="0dp" />
+</shape>

--- a/android-driver/res/values-v11/styles.xml
+++ b/android-driver/res/values-v11/styles.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <style name="FullscreenTheme">
+        <item name="android:textSelectHandle">@drawable/text_select_handle</item>
     </style>
 
 </resources>


### PR DESCRIPTION
We use android-driver-app. When you `sendKeys()` in text inputs android text select handle appears.
![example](http://i.stack.imgur.com/vsITs.png)
It is useless. It makes a noise on screenshots.
