### PR TITLE
Publish selendroid release artifacts to jcenter

### DIFF
--- a/android-driver/build.gradle
+++ b/android-driver/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
+apply from:   '../jacoco.gradle'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,31 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    ext.bintrayUser = project.hasProperty('bintrayUser') ? project.bintrayUser : System.getenv('BINTRAY_USER')
+    ext.bintrayKey = project.hasProperty('bintrayKey') ? project.bintrayKey : System.getenv('BINTRAY_KEY')
+    ext.bintrayEnabled = project.bintrayUser && project.bintrayKey
+
+    dependencies {
+        if (bintrayEnabled) {
+            classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
+        }
+        // Find latest version at https://bintray.com/bintray/jcenter/org.jacoco%3Ajacoco/view
+        // Remove once this android bug is fixed: https://code.google.com/p/android/issues/detail?id=192875
+        classpath 'org.jacoco:org.jacoco.core:0.7.5.201505241946'
+    }
+}
+
+apply from: 'properties.gradle'
+group = selGroup
+
 allprojects {
     repositories {
         jcenter()
     }
 
-    version = '0.18.0-SNAPSHOT'
+    version = selVersion
 
     ext {
         // https://bintray.com/android/android-tools/com.android.tools.build.gradle/view
@@ -20,5 +42,66 @@ allprojects {
         sourceCompatibilityVersion = 1.7
         targetCompatibilityVersion = 1.7
         junit = 'junit:junit:4.12'
+    }
+
+    // Bintray script
+    if (bintrayEnabled) {
+        apply plugin: 'com.jfrog.bintray'
+        bintray {
+            publish = true
+            configurations = ['published', 'archives']
+            user = bintrayUser
+            key = bintrayKey
+            pkg {
+                repo = 'maven'
+                name = "${selGroup}:${selArtifactId}"
+                // an userOrg of selendroid can be added here
+                // userOrg = 'appium'
+                websiteUrl = selWebsite
+                issueTrackerUrl = selTracker
+                vcsUrl = selGit
+                desc = selDescription
+                licenses = ['Apache-2.0']
+                publicDownloadNumbers = true
+                version {
+                    name = selVersion
+                    desc = selDescription
+                    // https://github.com/bintray/gradle-bintray-plugin#buildgradle
+                    // Uncomment and add maven credentials to sync the artifacts.
+                    /* mavenCentralSync {
+                        sync = true
+                        user = 'userToken' // OSS user token
+                        password = 'paasword' // OSS user password
+                        // Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
+                        close = '1'
+                    } */
+                }
+            }
+        }
+    }
+
+    configurations {
+        published
+    }
+    apply plugin: 'maven'
+    plugins.withType(JavaPlugin) {
+        configurations {
+            published
+        }
+
+        task sourceJar(type: Jar) {
+            classifier = 'sources'
+            from sourceSets.main.allSource
+        }
+        task javadocJar(type: Jar) {
+            classifier = 'javadoc'
+            from javadoc.destinationDir
+        }
+
+        // Add the sourceJars to non-extractor modules
+        artifacts {
+            published sourceJar
+            published javadocJar
+        }
     }
 }

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,9 @@
+// Find latest version at https://bintray.com/bintray/jcenter/org.jacoco%3Ajacoco/view
+android {
+    // Use gradle createDebugCoverageReport or connectedCheck to generate jacoco coverage reports
+    buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
+    }
+}

--- a/properties.gradle
+++ b/properties.gradle
@@ -1,0 +1,7 @@
+ext.selArtifactId  = 'selendroid'
+ext.selGroup = 'io.selendroid'
+ext.selVersion = '0.18.0-SNAPSHOT'
+ext.selWebsite = 'https://github.com/selendroid/selendroid'
+ext.selTracker = 'https://github.com/selendroid/selendroid/issues'
+ext.selGit = 'https://github.com/selendroid/selendroid.git'
+ext.selDescription = 'Android UI testing framework'

--- a/selendroid-server/build.gradle
+++ b/selendroid-server/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
+apply from:   '../jacoco.gradle'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/selendroid-test-app/build.gradle
+++ b/selendroid-test-app/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
+apply from:   '../jacoco.gradle'
 
 dependencies {
     compile 'com.android.support:support-v4:23.1.0'


### PR DESCRIPTION
### Commit summary:
This commit would enable us to publish the release artifacts to jcenter using the command 
`gradle -PbintrayUser=<username> -PbintrayKey=<key> clean bintrayUpload`.
( where `<username>` and `<key>` are bintray account's username and API key).

Also, the published artifacts can be automatically synced to maven central repository by using OSS credentials under `bintray` task of gradle script.