### PR TITLE
Add local.properties to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ selendroid.iws
 gradle/
 gradlew
 gradlew.bat
+local.properties
 
 build/


### PR DESCRIPTION
After running `gradle clean build` I ended up with a `local.properties`
file in the root of my repository. The file first line of this file
warns to not check it into source control, so let's add it to the
`.gitignore`.

```
$ head -n 1 local.properties
# DO NOT check this file into source control.
```