### PR TITLE
Add option to start selendroid standalone on a random port

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidLauncher.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidLauncher.java
@@ -90,9 +90,9 @@ public class SelendroidLauncher {
     launchServer();
     if (config.isGrid()) {
       // Longer timeout to allow for grid registration
-      HttpClientUtil.waitForServer(config.getPort(), 3, TimeUnit.MINUTES);
+      HttpClientUtil.waitForServer(server.getPort(), 3, TimeUnit.MINUTES);
     } else {
-      HttpClientUtil.waitForServer(config.getPort(), 20, TimeUnit.SECONDS);
+      HttpClientUtil.waitForServer(server.getPort(), 20, TimeUnit.SECONDS);
     }
   }
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/SelendroidStandaloneServer.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/SelendroidStandaloneServer.java
@@ -70,10 +70,11 @@ public class SelendroidStandaloneServer {
       selfRegisterInGrid();
     }
 
-    log.info("Selendroid standalone server has been started on port: " + config.getPort());
+    log.info("Selendroid standalone server has been started on port: " + getPort());
   }
 
   private void selfRegisterInGrid() {
+    config.setPort(webServer.getPort()); // Update configuration to include randomly assigned port
     final SelfRegisteringRemote selfRegisteringRemote = new SelfRegisteringRemote(config, driver);
 
     if (config.getRegisterCycle() > 0) {


### PR DESCRIPTION
There are cases where you don't care about the port selendroid
standalone starts on, as long as you can get the port after it started.
This commit changes the webserver start method to block until the netty
channel has opened and the netty thread returned the actual port the
server has started on.

Starting the standalone server on a random port can be achieved by using
0 as the configured port.