### PR TITLE
Add option to re-use configured server port

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
@@ -54,6 +54,11 @@ public class SelendroidConfiguration {
       names = {"-selendroidServerPort"})
   private int selendroidServerPort = 8080;
 
+  @Parameter(
+      description = "re-use the configured -selendroidServerPort for each test session",
+      names = {"-reuseSelendroidServerPort"})
+  private boolean reuseSelendroidServerPort = false;
+
   @Parameter(description = "The file of the keystore to be used", names = {"-keystore"})
   private String keystore = null;
 
@@ -466,5 +471,13 @@ public class SelendroidConfiguration {
 
   public void setNodeStatusCheckTimeout(long nodeStatusCheckTimeout) {
     this.nodeStatusCheckTimeout = nodeStatusCheckTimeout;
+  }
+
+  public boolean isReuseSelendroidServerPort() {
+    return reuseSelendroidServerPort;
+  }
+
+  public void setReuseSelendroidServerPort(boolean reuseSelendroidServerPort) {
+    this.reuseSelendroidServerPort = reuseSelendroidServerPort;
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -245,7 +245,10 @@ public class SelendroidStandaloneDriver implements ServerDetails {
           device.clearUserData(app);
         }
 
-        int port = getNextSelendroidServerPort();
+        int port = serverConfiguration.isReuseSelendroidServerPort()
+            ? serverConfiguration.getSelendroidServerPort()
+            : getNextSelendroidServerPort();
+
         boolean serverInstalled = device.isInstalled("io.selendroid." + app.getBasePackage());
         if (!serverInstalled || serverConfiguration.isForceReinstall()) {
           try {


### PR DESCRIPTION
For some reason the standalone server will assign a new selendroid
server port to the client each time a new session is created. Made this
behavior configurable and default to whatever the behavior was before.