### PR TITLE
Add support for launching implicit intents

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/InstrumentationArguments.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/InstrumentationArguments.java
@@ -22,12 +22,14 @@ import io.selendroid.server.extension.BootstrapHandler;
 public class InstrumentationArguments {
   // Copy to avoid holding reference to the Bundle
   private final String mainActivityClassName;
+  private final String intentUri;
   private final boolean loadExtensions;
   private final String bootstrapClassNames;
   private final String serverPort;
 
   public InstrumentationArguments(Bundle arguments) {
     mainActivityClassName = arguments.getString("main_activity");
+    intentUri = arguments.getString("intent_uri");
     loadExtensions = Boolean.parseBoolean(arguments.getString("load_extensions"));
     bootstrapClassNames = arguments.getString("bootstrap");
     serverPort = arguments.getString("server_port");
@@ -37,7 +39,11 @@ public class InstrumentationArguments {
   public String getActivityClassName() {
     return mainActivityClassName;
   }
-  
+
+  public String getIntentUri() {
+    return intentUri;
+  }
+
   /** Should we load extensions (assumes they have already been pushed to the device) */
   public boolean isLoadExtensions() {
     return loadExtensions;

--- a/selendroid-server/src/main/java/io/selendroid/server/LightweightInstrumentation.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/LightweightInstrumentation.java
@@ -60,7 +60,12 @@ public class LightweightInstrumentation extends Instrumentation {
                 }
 
                 // Start the new activity
-                Intent intent = Intents.createStartActivityIntent(context, args.getActivityClassName());
+                Intent intent;
+                if (args.getActivityClassName() != null) {
+                    intent = Intents.createStartActivityIntent(context, args.getActivityClassName());
+                } else {
+                    intent = Intents.createUriIntent(args.getIntentUri());
+                }
                 context.startActivity(intent);
             }
         });

--- a/selendroid-server/src/main/java/io/selendroid/server/ServerInstrumentation.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/ServerInstrumentation.java
@@ -52,6 +52,7 @@ public class ServerInstrumentation extends Instrumentation implements ServerDeta
   private ActivitiesReporter activitiesReporter = new ActivitiesReporter();
   private static ServerInstrumentation instance = null;
   public static String mainActivityName = null;
+  public static String intentUri = null;
   private HttpdThread serverThread = null;
   private AndroidWait androidWait = new AndroidWait();
   private PowerManager.WakeLock wakeLock;
@@ -65,7 +66,11 @@ public class ServerInstrumentation extends Instrumentation implements ServerDeta
 
   public void startMainActivity() {
     doFinishAllActivities();
-    startActivity(mainActivityName);
+    if (mainActivityName != null) {
+      startActivity(mainActivityName);
+    } else {
+      getTargetContext().startActivity(Intents.createUriIntent(intentUri));
+    }
   }
 
   public void startActivity(String activityClassName) {
@@ -105,6 +110,7 @@ public class ServerInstrumentation extends Instrumentation implements ServerDeta
     this.args = new InstrumentationArguments(arguments);
 
     mainActivityName = arguments.getString("main_activity");
+    intentUri = arguments.getString("intent_uri");
 
     int parsedServerPort = 0;
 
@@ -122,7 +128,13 @@ public class ServerInstrumentation extends Instrumentation implements ServerDeta
       this.serverPort = parsedServerPort;
     }
 
-    SelendroidLogger.info("Instrumentation initialized with main activity: " + mainActivityName);
+    String destination;
+    if (mainActivityName != null) {
+      destination = "main activity: " + mainActivityName;
+    } else {
+      destination = "URI: " + intentUri;
+    }
+    SelendroidLogger.info("Instrumentation initialized with " + destination);
     instance = this;
 
     final Context context = getTargetContext();

--- a/selendroid-server/src/main/java/io/selendroid/server/util/Intents.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/util/Intents.java
@@ -25,6 +25,8 @@ public class Intents {
      * Create an implicit intent based on the given URI.
      */
     public static Intent createUriIntent(String intentUri) {
-        return new Intent(Intent.ACTION_VIEW, Uri.parse(intentUri));
+        return new Intent(Intent.ACTION_VIEW, Uri.parse(intentUri))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
+                        | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
     }
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/util/Intents.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/util/Intents.java
@@ -2,6 +2,7 @@ package io.selendroid.server.util;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 
 /**
  * A helper class for working with intents
@@ -18,5 +19,12 @@ public class Intents {
         intent.setAction(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_LAUNCHER);
         return intent;
+    }
+
+    /**
+     * Create an implicit intent based on the given URI.
+     */
+    public static Intent createUriIntent(String intentUri) {
+        return new Intent(Intent.ACTION_VIEW, Uri.parse(intentUri));
     }
 }


### PR DESCRIPTION
Sometimes a test may want to launch an Activity via URI (e.g. to encode
a user ID or other information). This adds an "intent_uri" option to
both lightweight and regular server instrumentation that acts as a
fallback in case the main activity name is not specified.

/cc @asm89 