### PR TITLE
get ANDROID_HOME from Property

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidSdk.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidSdk.java
@@ -95,6 +95,10 @@ public class AndroidSdk {
     String androidHome = System.getenv(ANDROID_HOME);
 
     if (androidHome == null) {
+      androidHome = System.getProperty(ANDROID_HOME);
+    }
+
+    if (androidHome == null) {
       throw new SelendroidException("Environment variable '" + ANDROID_HOME + "' was not found!");
     }
     return androidHome;


### PR DESCRIPTION
If not found in OS  vars, lookup from JVM Properties.
This is very helpful for avoiding restart user's PC.