### PR TITLE
fix  the scroll-to-be-visible click not working problem

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
@@ -200,7 +200,7 @@ public class AndroidNativeElement implements AndroidElement {
         synchronized (syncObject) {
           Rect r = new Rect(left, top, getView().getWidth(), getView().getHeight());
 
-          getView().requestRectangleOnScreen(r);
+          getView().requestRectangleOnScreen(r, true);
           done = true;
           syncObject.notify();
         }


### PR DESCRIPTION
this commit is to fix invisible element scrolliing to visible but not been clicked.

### Reason

`View.requestRectangleOnScreen` method is an async method. it will return immediately, and the scroll action occurs at the same time.
So the wait code after scroll in `scrollIntoScreenIfNeeded` method would be jumped over.
Then the click would be triggered, but the scroll animation is still playing. So the click action did not work.

### Fix

add second parameter in `View.requestRectangleOnScreen`: set to `true` to forbid the scrolling animation.

Maybe we could even remove the wait code in `scrollIntoScreenIfNeeded` as it is not working. Maybe I do not understand its meaning. so my PR did not do that.