### PR TITLE
Remove Jacoco from selendroid-server

### DIFF
--- a/selendroid-server/build.gradle
+++ b/selendroid-server/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 
 apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
-apply from:   '../jacoco.gradle'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
CI build is breaking because it's unable to instrument `selendroid-server/build/intermediates/classes/debug/io/selendroid/server/model/js/AndroidAtoms.class `. This PR removes Jacoco form the selendroid-server module to prevent this