### PR TITLE
adding support for Android25

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/common/device/DeviceTargetPlatform.java
+++ b/selendroid-common/src/main/java/io/selendroid/common/device/DeviceTargetPlatform.java
@@ -16,7 +16,7 @@ package io.selendroid.common.device;
 public enum DeviceTargetPlatform {
 	  ANDROID10("2.3.3"), ANDROID11("3.0"), ANDROID12("3.1"), ANDROID13("3.2"), ANDROID14("4.0"), 
 	  ANDROID15("4.0.3"), ANDROID16("4.1.2"), ANDROID17("4.2.2"), ANDROID18("4.3"), ANDROID19("4.4"), 
-	  ANDROID20("4.4"), ANDROID21("5.0"), ANDROID22("5.1"), ANDROID23("6.0");
+	  ANDROID20("4.4"), ANDROID21("5.0"), ANDROID22("5.1"), ANDROID23("6.0"), ANDROID25("7.1");
   public static final String ANDROID = "ANDROID";
 
   private String versionNumber;

--- a/selendroid-standalone/build.gradle
+++ b/selendroid-standalone/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile 'org.apache.commons:commons-exec:1.1'
     compile 'org.apache.commons:commons-compress:1.5'
     compile 'com.beust:jcommander:1.30'
-    compile 'com.android.tools.ddms:ddmlib:23.0.1'
+    compile 'com.android.tools.ddms:ddmlib:25.3.1'
     compile 'com.google.guava:guava:17.0'
     compile 'org.apache.commons:commons-lang3:3.1'
     // https://bintray.com/bintray/jcenter/org.seleniumhq.selenium%3Aselenium-java/2.48.2/view#files

--- a/selendroid-standalone/pom.xml
+++ b/selendroid-standalone/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.android.tools.ddms</groupId>
             <artifactId>ddmlib</artifactId>
-            <version>23.0.1</version>
+            <version>25.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
I saw someone else's pull request for ANDROID24 so I left it out.  I also needed to update the ddmlib version to parse line numbers correctly.  using version 23 no properties were parsed.