### PR TITLE
Fix install command for Nougat

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -138,7 +138,7 @@ public abstract class AbstractDevice implements AndroidDevice {
     }
     // -r: replace existing application
     // -d: allow version code downgrade
-    CommandLine command = adbCommand("install", "-rd", app.getAbsolutePath());
+    CommandLine command = adbCommand("install", "-r", "-d", app.getAbsolutePath());
 
     String out = executeCommandQuietly(command, COMMAND_TIMEOUT * 6);
     try {


### PR DESCRIPTION
Combining multiple arguments was never officially supported by `adb`, it may not be supported by some devices and, on Nougat, it always fails. Simply separate the `r` and `d` arguments