### PR TITLE
Move extra AUT args to a JSON file

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -57,7 +57,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public static final String PLATFORM_VERSION = "platformVersion";
   public static final String PLATFORM_NAME = "platformName";
   public static final String AUTOMATION_NAME = "automationName";
-  
+
   public static final String LAUNCH_ACTIVITY = "launchActivity";
   public static final String SELENDROID_EXTENSIONS = "selendroidExtensions";
   public static final String BOOTSTRAP_CLASS_NAMES = "bootstrapClassNames";
@@ -181,7 +181,23 @@ public class SelendroidCapabilities extends DesiredCapabilities {
     return getRawCapabilities().containsKey(EXTRA_ARGS);
   }
 
+  public void addExtraAUTArg(String key, boolean value) {
+    doAddExtraAUTArg(key, value);
+  }
+
+  public void addExtraAUTArg(String key, int value) {
+    doAddExtraAUTArg(key, value);
+  }
+
   public void addExtraAUTArg(String key, String value) {
+    doAddExtraAUTArg(key, value);
+  }
+
+  public void addExtraAUTArg(String key, JSONObject value) {
+    doAddExtraAUTArg(key, value);
+  }
+
+  private void doAddExtraAUTArg(String key, Object value) {
     JSONObject extraArgs = getExtraAUTArgs();
 
     if (extraArgs == null) {
@@ -192,7 +208,14 @@ public class SelendroidCapabilities extends DesiredCapabilities {
       extraArgs.put(key, value);
       setCapability(EXTRA_ARGS, extraArgs);
     } catch (JSONException e) {
-      LOGGER.log(Level.WARNING, "Failed to add extra arg: '" + key + "':'" + value + "'");
+      throw new RuntimeException(
+        String.format(
+          "Failed to add extra AUT arg with key %s and value %s",
+          key,
+          value.toString()
+        ),
+        e
+      );
     }
   }
 
@@ -220,7 +243,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public void setAut(String aut) {
     setCapability(AUT, aut);
   }
-  
+
   public void setLaunchActivity(String launchActivity) {
 	setCapability(LAUNCH_ACTIVITY, launchActivity);
   }
@@ -297,7 +320,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   }
 
   /**
-   * 
+   *
    * @param aut The application under test. Expected format is basePackage:version. E.g.:
    *        io.selendroid.testapp:0.4
    * @return Desired Capabilities of an emulator.
@@ -310,7 +333,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   }
 
   /**
-   * 
+   *
    * @param platform The Android target platform to use.
    * @param aut The application under test. Expected format is basePackage:version. E.g.:
    *        io.selendroid.testapp:0.4
@@ -352,7 +375,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   /**
    * Command like: "shell setprop name selendroid", please note that the adb command itself and the
    * serial will be added by selendroid automatically.
-   * 
+   *
    * @param commands The list of ADB commands that will be executed before the test session starts
    *        on the device.
    */
@@ -361,7 +384,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   }
 
   /**
-   * 
+   *
    * @param platform The Android target platform to use.
    * @param aut The application under test. Expected format is basePackage:version. E.g.:
    *        io.selendroid.testapp:0.4
@@ -375,7 +398,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   }
 
   /**
-   * 
+   *
    * @param aut The application under test. Expected format is basePackage:version. E.g.:
    *        io.selendroid.testapp:0.4
    * @return Desired Capabilities of an device.
@@ -400,7 +423,7 @@ public class SelendroidCapabilities extends DesiredCapabilities {
       return o;
     }
   }
-  
+
   /**
    * Returns a copy of this instance with {@code caps} merged, overwriting existing keys on
    * collision.

--- a/selendroid-server/src/main/java/io/selendroid/server/DefaultServerInstrumentation.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/DefaultServerInstrumentation.java
@@ -36,6 +36,7 @@ import io.selendroid.server.model.ExternalStorage;
 import io.selendroid.server.util.Intents;
 import io.selendroid.server.util.SelendroidLogger;
 import org.json.JSONArray;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -228,12 +229,12 @@ public class DefaultServerInstrumentation implements ServerInstrumentation {
     }
 
     @Override
-    public Map<String, String> getExtraArgs() {
+    public JSONObject getExtraArgs() {
       return args.getExtraArgs();
     }
 
     @Override
-    public String getExtraArg(String key) {
+    public Object getExtraArg(String key) {
       return args.getExtraArg(key);
     }
 

--- a/selendroid-server/src/main/java/io/selendroid/server/ServerInstrumentation.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/ServerInstrumentation.java
@@ -25,6 +25,8 @@ import io.selendroid.server.extension.ExtensionLoader;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONObject;
+
 public interface ServerInstrumentation extends ServerDetails {
   void onCreate();
   void onDestroy();
@@ -46,6 +48,6 @@ public interface ServerInstrumentation extends ServerDetails {
   List<CallLogEntry> readCallLog();
   Instrumentation getInstrumentation();
   ExtensionLoader getExtensionLoader();
-  Map<String, String> getExtraArgs();
-  String getExtraArg(String key);
+  JSONObject getExtraArgs();
+  Object getExtraArg(String key);
 }

--- a/selendroid-server/src/main/java/io/selendroid/server/model/ExternalStorage.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/ExternalStorage.java
@@ -35,6 +35,10 @@ public class ExternalStorage {
     return new File(getExternalStorageDir(), "extension.dex");
   }
 
+  public static File getExtraArgsFile() {
+    return new File(getExternalStorageDir(), "extra_args.json");
+  }
+
   public static File getCrashLog() {
     return new File(getExternalStorageDir(), ExternalStorageFile.APP_CRASH_LOG.toString());
   }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -72,7 +72,7 @@ public abstract class AbstractDevice implements AndroidDevice {
    * Constructor meant to be used with Android Emulators because a reference to the {@link IDevice}
    * will become available if the emulator will be started. Please make sure that #setIDevice is
    * called on the emulator.
-   * 
+   *
    * @param serial
    */
   public AbstractDevice(String serial) {
@@ -82,7 +82,7 @@ public abstract class AbstractDevice implements AndroidDevice {
   /**
    * Constructor mean to be used with Android Hardware devices because a reference to the
    * {@link IDevice} will be available immediately after they are connected.
-   * 
+   *
    * @param device
    */
   public AbstractDevice(IDevice device) {
@@ -171,7 +171,7 @@ public abstract class AbstractDevice implements AndroidDevice {
     }
     return out.contains("Starting: Intent");
   }
-  
+
   protected String executeCommandQuietly(CommandLine command) {
     return executeCommandQuietly(command, COMMAND_TIMEOUT);
   }
@@ -270,20 +270,6 @@ public abstract class AbstractDevice implements AndroidDevice {
       argList.addAll(Lists.newArrayList("-e", SelendroidArguments.LOAD_EXTENSIONS, "true"));
       if (capabilities.getBootstrapClassNames() != null) {
         argList.addAll(Lists.newArrayList("-e", SelendroidArguments.BOOTSTRAP, capabilities.getBootstrapClassNames()));
-      }
-    }
-
-    if (capabilities.hasExtraAUTArgs()) {
-      try {
-        JSONObject extraArgs = capabilities.getExtraAUTArgs();
-
-        Iterator<String> keys = extraArgs.keys();
-        while (keys.hasNext()) {
-          final String key = keys.next();
-          argList.addAll(Lists.newArrayList("-e", key, (String) extraArgs.get(key)));
-        }
-      } catch (JSONException e) {
-        log.log(Level.WARNING, "Failed to read extra AUT args", e);
       }
     }
 
@@ -603,7 +589,7 @@ public abstract class AbstractDevice implements AndroidDevice {
     // make sure it's backup again
     executeCommandQuietly(adbCommand("devices"));
   }
-  
+
   private CommandLine adbCommand() {
     CommandLine command = new CommandLine(AndroidSdk.adb());
     if (isSerialConfigured()) {
@@ -688,7 +674,7 @@ public abstract class AbstractDevice implements AndroidDevice {
   public String getModel() {
     return model;
   }
-  
+
   public String getAPITargetType() {
     return apiTargetType;
   }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -383,7 +383,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
       File temp = File.createTempFile("extra_args", ".json");
       FileUtils.write(temp, fileContents);
 
-      log.debug("Pushing new extra args file to device");
+      log.info("Pushing new extra args file to device");
       device.runAdbCommand(
         String.format("push %s %s", temp.getAbsolutePath(), devicePath)
       );


### PR DESCRIPTION
This PR changes the way in which we send extra AUT args. Instead of using the instrument command's arguments, we now write the arguments to a JSON file and push it to the device. This will free us from having to worry about the character limit on `adb` command arguments and will also allow us to send more structured args (we now support passing arbitrary `JSONObject`s)