### PR TITLE
Proxy WebViewClient calls for a WebView subclass

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
@@ -444,7 +444,23 @@ public class SelendroidWebDriver {
   }
 
   private Object reflectionGet(Object object, String field) throws NoSuchFieldException, IllegalAccessException {
-    Field f = object.getClass().getDeclaredField(field);
+    Field f = null;
+    Class clazz = object.getClass();
+    NoSuchFieldException ex = null;
+    while (f == null && clazz != null) {
+      try {
+        f = clazz.getDeclaredField(field);
+        break;
+      } catch (NoSuchFieldException nsfe) {
+        if (ex == null) {
+          ex = nsfe;
+        }
+        clazz = clazz.getSuperclass();
+      }
+    }
+    if (f == null) {
+      throw ex;
+    }
     f.setAccessible(true);
     return f.get(object);
   }

--- a/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
@@ -447,6 +447,8 @@ public class SelendroidWebDriver {
     Field f = null;
     Class clazz = object.getClass();
     NoSuchFieldException ex = null;
+    // Look for the field in the object's class or its class hierarchy.
+    // This is useful if you are testing a subclass of WebView.
     while (f == null && clazz != null) {
       try {
         f = clazz.getDeclaredField(field);


### PR DESCRIPTION
If an application uses a WebView, Selendroid creates a WrappingSelendroidWebClient, so that WebViewClient events can be sent both to the application's own WebViewClient as well as Selendroid's WebViewClient.  (For more context, see commit a1a6a3b0943e8c6516ea49dcaa23a77e245a5b7b.)

However, if an application used a subclass of WebView, a WrappingSelendroidWebClient would not get created, because Class.getDeclaredField() did not check the fields up the class hierarchy.

The fix is to walk up the class hierarchy, looking for the field along the way.