### PR TITLE
Increase click reliability for API levels 19+

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
@@ -259,13 +259,11 @@ public class AndroidNativeElement implements AndroidElement {
 
     final View view = getView();
 
-    final int viewWidth = view.getWidth();
-    final int viewHeight = view.getHeight();
     final int[] xy = new int[2];
 
     if (viewWidth > 0 && viewHeight > 0) {
       view.getLocationOnScreen(xy);
-      clickOnScreen(xy[0] + viewWidth / 2.0f, xy[1] + viewHeight / 2.0f);
+      clickOnScreen(xy[0] + view.getWidth() / 2.0f, xy[1] + view.getHeight() / 2.0f);
       return;
     }
 
@@ -275,7 +273,7 @@ public class AndroidNativeElement implements AndroidElement {
       public void onGlobalLayout() {
         try {
           view.getLocationOnScreen(xy);
-          clickOnScreen(xy[0] + viewWidth / 2.0f, xy[1] + viewHeight / 2.0f);
+          clickOnScreen(xy[0] + view.getWidth() / 2.0f, xy[1] + view.getHeight() / 2.0f);
         } finally {
           if (observer.isAlive()) {
             removeOnGlobalLayoutListener(observer, this);

--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
@@ -260,8 +260,6 @@ public class AndroidNativeElement implements AndroidElement {
 
     final View view = getView();
 
-    final int[] xy = new int[2];
-
     if (Build.VERSION.SDK_INT < 19 || view.isLaidOut()) {
       if (Build.VERSION.SDK_INT < 19) {
         try {
@@ -271,8 +269,7 @@ public class AndroidNativeElement implements AndroidElement {
         } catch (InterruptedException e) {}
       }
 
-      view.getLocationOnScreen(xy);
-      clickOnScreen(xy[0] + view.getWidth() / 2.0f, xy[1] + view.getHeight() / 2.0f);
+      doClick();
       return;
     }
 
@@ -303,6 +300,13 @@ public class AndroidNativeElement implements AndroidElement {
     } catch (TimeoutException e) {
       throw new SelendroidException("View was never laid out", e);
     }
+
+    doClick();
+  }
+
+  private void doClick() {
+    final View view = getView();
+    final int[] xy = new int[2];
 
     view.getLocationOnScreen(xy);
     clickOnScreen(xy[0] + view.getWidth() / 2.0f, xy[1] + view.getHeight() / 2.0f);

--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
@@ -276,13 +276,13 @@ public class AndroidNativeElement implements AndroidElement {
     }
 
     final AndroidWait wait = instrumentation.getAndroidWait();
-    boolean isLaidOut = false;
+    final BooleanWrapper isLaidOut = new BooleanWrapper();
     final ViewTreeObserver observer = view.getViewTreeObserver();
     observer.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
       @Override
       public void onGlobalLayout() {
         try {
-          isLaidOut = true;
+          isLaidOut.value = true;
         } finally {
           if (observer.isAlive()) {
             removeOnGlobalLayoutListener(observer, this);
@@ -296,7 +296,7 @@ public class AndroidNativeElement implements AndroidElement {
       wait.until(new Function<Void, Boolean>() {
         @Override
         public Boolean apply(Void input) {
-          return isLaidOut;
+          return isLaidOut.value;
         }
       });
     } catch (TimeoutException e) {
@@ -305,6 +305,10 @@ public class AndroidNativeElement implements AndroidElement {
 
     view.getLocationOnScreen(xy);
     clickOnScreen(xy[0] + view.getWidth() / 2.0f, xy[1] + view.getHeight() / 2.0f);
+  }
+
+  private class BooleanWrapper {
+    public boolean value = false;
   }
 
   private void removeOnGlobalLayoutListener(

--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
@@ -36,6 +36,7 @@ import io.selendroid.server.util.SelendroidLogger;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -276,13 +277,13 @@ public class AndroidNativeElement implements AndroidElement {
     }
 
     final AndroidWait wait = instrumentation.getAndroidWait();
-    final BooleanWrapper isLaidOut = new BooleanWrapper();
+    final AtomicBoolean isLaidOut = new AtomicBoolean(false);
     final ViewTreeObserver observer = view.getViewTreeObserver();
     observer.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
       @Override
       public void onGlobalLayout() {
         try {
-          isLaidOut.value = true;
+          isLaidOut.set(true);
         } finally {
           if (observer.isAlive()) {
             removeOnGlobalLayoutListener(observer, this);
@@ -296,7 +297,7 @@ public class AndroidNativeElement implements AndroidElement {
       wait.until(new Function<Void, Boolean>() {
         @Override
         public Boolean apply(Void input) {
-          return isLaidOut.value;
+          return isLaidOut.get();
         }
       });
     } catch (TimeoutException e) {
@@ -305,10 +306,6 @@ public class AndroidNativeElement implements AndroidElement {
 
     view.getLocationOnScreen(xy);
     clickOnScreen(xy[0] + view.getWidth() / 2.0f, xy[1] + view.getHeight() / 2.0f);
-  }
-
-  private class BooleanWrapper {
-    public boolean value = false;
   }
 
   private void removeOnGlobalLayoutListener(

--- a/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/AndroidNativeElement.java
@@ -261,7 +261,15 @@ public class AndroidNativeElement implements AndroidElement {
 
     final int[] xy = new int[2];
 
-    if (viewWidth > 0 && viewHeight > 0) {
+    if (Build.VERSION.SDK_INT < 19 || view.isLaidOut()) {
+      if (Build.VERSION.SDK_INT < 19) {
+        try {
+          // This is needed for recalculation of location when we cannot
+          // explicitly check if the view's been laid out
+          Thread.sleep(300);
+        } catch (InterruptedException e) {}
+      }
+
       view.getLocationOnScreen(xy);
       clickOnScreen(xy[0] + view.getWidth() / 2.0f, xy[1] + view.getHeight() / 2.0f);
       return;
@@ -292,10 +300,10 @@ public class AndroidNativeElement implements AndroidElement {
       return;
     }
 
-    if (Build.VERSION.SDK_INT >= 16) {
-      observer.removeOnGlobalLayoutListener(listener);
-    } else {
+    if (Build.VERSION.SDK_INT < 16) {
       observer.removeGlobalOnLayoutListener(listener);
+    } else {
+      observer.removeOnGlobalLayoutListener(listener);
     }
   }
 


### PR DESCRIPTION
The previous implementation of the click method would simply wait for a specific amount of time and then try to access the view's location. That approach offers no guarantee that the `getLocationOnScreen` would return a valid value.

This PR checks if the view's been laid out before calling `getLocationOnScreen`, if it hasn't been it attaches an `OnGlobalLayoutListener` to the view tree that will perform the click once the view's been properly laid out.

Note that `isLaidOut` is only available in API 19+, so we fallback to the original implementation for lower API levels