### PR TITLE
Make android home, sdk and build-tools configurable

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
@@ -177,6 +177,15 @@ public class SelendroidConfiguration {
   @Parameter(names = "-useJUnitBootstrap", description = "Use instrumentation that extends AdroidJUnitRunner")
   private boolean useJUnitBootstrap = false;
 
+  @Parameter(names = "-androidHome", description = "Specify path to android sdk installation, if not specified it will be read from the ANDROID_HOME env var")
+  private String androidHome = null;
+
+  @Parameter(names = "-androidSdkVersion", description = "Which Android SDK version to use to build the selendroid-server")
+  private String androidSdkVersion = null;
+
+  @Parameter(names = "-buildToolsVersion", description = "Which version of the android build-tools to use")
+  private String buildToolsVersion = null;
+
   public void setKeystore(String keystore) {
     this.keystore = keystore;
   }
@@ -490,5 +499,29 @@ public class SelendroidConfiguration {
 
   public void setUseJUnitBootstrap(boolean useJUnitBootstrap) {
     this.useJUnitBootstrap = useJUnitBootstrap;
+  }
+
+  public String getAndroidHome() {
+    return androidHome;
+  }
+
+  public void setAndroidHome(String androidHome) {
+    this.androidHome = androidHome;
+  }
+
+  public String getAndroidSdkVersion() {
+    return androidSdkVersion;
+  }
+
+  public void setAndroidSdkVersion(String androidSdkVersion) {
+    this.androidSdkVersion = androidSdkVersion;
+  }
+
+  public String getBuildToolsVersion() {
+    return buildToolsVersion;
+  }
+
+  public void setBuildToolsVersion(String buildToolsVersion) {
+    this.buildToolsVersion = buildToolsVersion;
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidLauncher.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidLauncher.java
@@ -17,6 +17,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.google.common.base.Throwables;
 
+import io.selendroid.standalone.android.AndroidSdk;
 import io.selendroid.standalone.exceptions.AndroidSdkException;
 import io.selendroid.standalone.log.LogLevelEnum;
 import io.selendroid.standalone.server.SelendroidStandaloneServer;
@@ -61,6 +62,21 @@ public class SelendroidLauncher {
    */
   private void launchServer() {
     try {
+      log.info("Configuring Android SDK");
+      if (config.getAndroidHome() != null) {
+        AndroidSdk.setAndroidHome(config.getAndroidHome());
+      }
+      if (config.getAndroidSdkVersion() != null) {
+        AndroidSdk.setAndroidSdkVersion(config.getAndroidSdkVersion());
+      }
+      if (config.getBuildToolsVersion() != null) {
+        AndroidSdk.setBuildToolsVersion(config.getBuildToolsVersion());
+      }
+
+      log.info("Using Android SDK installed in: " + AndroidSdk.androidHome());
+      log.info("Using Android SDK version: " + AndroidSdk.androidSdkFolder().getAbsolutePath());
+      log.info("Using build-tolls in: " + AndroidSdk.buildToolsFolder().getAbsolutePath());
+
       log.info("Starting Selendroid standalone on port " + config.getPort());
       server = new SelendroidStandaloneServer(config);
       server.start();


### PR DESCRIPTION
This PR makes it possible to specify which android sdk installation (i.e. use ANDROID_HOME or other installation), sdk version and build-tools version to use via `SelendroidConfiguration`. This is useful in environments with multiple sdk installations and cases where the latest build-tools or android-sdk are not compatible with the AUT