### PR TITLE
list avds not working in high sdk

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
@@ -145,7 +145,7 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
 
     CommandLine cmd = new CommandLine(AndroidSdk.android());
     cmd.addArgument("list", false);
-    cmd.addArgument("avds", false);
+    cmd.addArgument("avd", false);
 
     String output = null;
     try {


### PR DESCRIPTION
Fix issue: https://github.com/selendroid/selendroid/issues/1107
Incompatible with SDK Tools 25, command "list avds" does not exist