### PR TITLE
Use real time in AndroidSystemClock

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/android/internal/AndroidSystemClock.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/android/internal/AndroidSystemClock.java
@@ -14,21 +14,21 @@
 package io.selendroid.server.android.internal;
 
 import io.selendroid.server.android.Clock;
-import android.os.Process;
+import android.os.SystemClock;
 
 public class AndroidSystemClock implements Clock {
   @Override
   public long now() {
-    return Process.getElapsedCpuTime();
+    return SystemClock.elapsedRealtime();
   }
 
   @Override
   public long laterBy(long durationInMillis) {
-    return Process.getElapsedCpuTime() + durationInMillis;
+    return now() + durationInMillis;
   }
 
   @Override
   public boolean isNowBefore(long endInMillis) {
-    return Process.getElapsedCpuTime() < endInMillis;
+    return now() < endInMillis;
   }
 }


### PR DESCRIPTION
Using CPU didn't really make sense here and in some causes could cause timeouts for waits to be way off