### PR TITLE
Fix Android SDK logic for finding latest build-tools/platform version

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidSdk.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidSdk.java
@@ -21,15 +21,19 @@ import io.selendroid.standalone.exceptions.AndroidSdkException;
 import java.io.File;
 import java.io.FileFilter;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Comparator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AndroidSdk {
-  private static final String ANDROID_FOLDER_PREFIX = "android-";
   private static final String ANDROID_HOME = "ANDROID_HOME";
 
   private static String sAndroidHome;
   private static String sAndroidSdkVersion;
   private static String sBuildToolsVersion;
+
+  private static final String PLATFORM_VERSION_REGEX = "android-(\\d+)$";
+  private static final String BUILD_TOOLS_VERSION_REGEX = "(\\d+)\\.(\\d+)\\.(\\d+)";
 
 
   public static File adb() {
@@ -47,21 +51,6 @@ public class AndroidSdk {
     }
 
     return new File(buildToolsFolder(), command.toString());
-  }
-
-  public static File buildToolsFolder() {
-    File buildToolsFolder = buildToolsHome();
-
-    if (sBuildToolsVersion != null) {
-      return new File(buildToolsFolder, sBuildToolsVersion);
-    } else {
-      return findLatestAndroidPlatformFolder(
-        buildToolsFolder,
-        String.format(
-          "Command 'aapt' was not found inside the Android SDK: %s. "
-          + "Please update to the latest development tools and try again.",
-          buildToolsFolder));
-    }
   }
 
   public static File android() {
@@ -124,25 +113,103 @@ public class AndroidSdk {
   }
 
   public static File androidSdkFolder() {
-    String platformsRootFolder = androidHome() + File.separator + "platforms";
-    File platformsFolder = new File(platformsRootFolder);
-
     if (sAndroidSdkVersion != null) {
-      return new File(platformsFolder, sAndroidSdkVersion);
-    } else {
-      return findLatestAndroidPlatformFolder(
-        platformsFolder,
-        "No installed Android APIs have been found.");
+      return new File(platformsFolder(), sAndroidSdkVersion);
     }
+    return findLatestAndroidPlatformFolder();
   }
 
-  protected static File findLatestAndroidPlatformFolder(File rootFolder, String errorMessage) {
-    File[] androidApis = rootFolder.listFiles(new AndroidFileFilter());
-    if (androidApis == null || androidApis.length == 0) {
-      throw new SelendroidException(errorMessage);
+  private static File platformsFolder() {
+    return new File(androidHome(), "platforms");
+  }
+
+  public static File findLatestAndroidPlatformFolder() {
+    return findLatestAndroidPlatformFolder(platformsFolder());
+  }
+
+  public static File findLatestAndroidPlatformFolder(File platformsFolder) {
+    File[] platformVersions = platformsFolder.listFiles(new FileFilter() {
+      @Override
+      public boolean accept(File file) {
+        return file.getName().matches(PLATFORM_VERSION_REGEX);
+      }
+    });
+
+    if (platformVersions == null || platformVersions.length == 0) {
+      throw new SelendroidException("No valid Android platform folder found in " + platformsFolder.getName());
     }
-    Arrays.sort(androidApis, Collections.reverseOrder());
-    return androidApis[0].getAbsoluteFile();
+
+    Pattern pattern = Pattern.compile(PLATFORM_VERSION_REGEX);
+    Arrays.sort(
+      platformVersions,
+      new Comparator<File>() {
+        @Override
+        public int compare(File f1, File f2) {
+          Matcher m1 = pattern.matcher(f1.getName());
+          Matcher m2 = pattern.matcher(f2.getName());
+
+          m1.find();
+          m2.find();
+
+          return Integer.compare(
+            Integer.parseInt(m1.group(1)),
+            Integer.parseInt(m2.group(1)));
+        }
+      });
+
+    return platformVersions[platformVersions.length - 1].getAbsoluteFile();
+  }
+
+  public static File buildToolsFolder() {
+    if (sBuildToolsVersion != null) {
+      return new File(buildToolsHome(), sBuildToolsVersion);
+    }
+    return findLatestBuildToolsFolder();
+  }
+
+  public static File findLatestBuildToolsFolder() {
+    return findLatestBuildToolsFolder(buildToolsHome());
+  }
+
+  public static File findLatestBuildToolsFolder(File buildToolsHome) {
+    File[] buildToolsVersions = buildToolsHome.listFiles(new FileFilter() {
+      @Override
+      public boolean accept(File file) {
+        return file.getName().matches(BUILD_TOOLS_VERSION_REGEX);
+      }
+    });
+
+    if (buildToolsVersions == null || buildToolsVersions.length == 0) {
+      throw new SelendroidException("No valid build-tools versions found in " + buildToolsHome.getName());
+    }
+
+    Pattern pattern = Pattern.compile(BUILD_TOOLS_VERSION_REGEX);
+    Arrays.sort(
+      buildToolsVersions,
+      new Comparator<File>() {
+        @Override
+        public int compare(File f1, File f2) {
+          Matcher m1 = pattern.matcher(f1.getName());
+          Matcher m2 = pattern.matcher(f2.getName());
+
+          m1.find();
+          m2.find();
+
+          for (int i = 1; i <= 3; i++) {
+            int compare = Integer.compare(
+              Integer.parseInt(m1.group(i)),
+              Integer.parseInt(m2.group(i)));
+
+            if (compare != 0) {
+              return compare;
+            }
+          }
+
+          return 0;
+        }
+      });
+
+    return buildToolsVersions[buildToolsVersions.length - 1].getAbsoluteFile();
   }
 
   public static void setAndroidHome(String androidHome) {
@@ -155,19 +222,5 @@ public class AndroidSdk {
 
   public static void setBuildToolsVersion(String buildToolsVersion) {
     sBuildToolsVersion = buildToolsVersion;
-  }
-
-  public static class AndroidFileFilter implements FileFilter {
-
-    @Override
-    public boolean accept(File pathname) {
-      String fileName = pathname.getName();
-
-      String regex = "\\d{2}\\.\\d{1}\\.\\d{1}";
-      if (fileName.matches(regex) || fileName.startsWith(ANDROID_FOLDER_PREFIX)) {
-        return true;
-      }
-      return false;
-    }
   }
 }

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/AndroidSdkTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/AndroidSdkTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.selendroid.standalone.android;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+
+import io.selendroid.standalone.android.AndroidSdk;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AndroidSdkTest {
+  @Test
+  public void testGetLatestPlatformFolder() {
+    File mockPlatformsFolder = mock(File.class);
+    when(
+      mockPlatformsFolder.listFiles(any(FileFilter.class))
+    ).thenReturn(new File[] {
+        new File("/", "android-9"),
+        new File("/", "android-21"),
+        new File("/", "android-22"),
+        new File("/", "android-13")
+      });
+
+    Assert.assertEquals(
+      "Find latest platform folder should be android-22",
+      AndroidSdk.findLatestAndroidPlatformFolder(mockPlatformsFolder).getAbsolutePath(),
+      new File("/", "android-22").getAbsolutePath());
+  }
+
+  @Test
+  public void testGetLatestBuildToolsFolder() {
+    File mockBuildToolsHome = mock(File.class);
+    when(
+      mockBuildToolsHome.listFiles(any(FileFilter.class))
+    ).thenReturn(new File[] {
+        new File("/", "22.0.0"),
+        new File("/", "22.0.3"),
+        new File("/", "22.0.1"),
+        new File("/", "25.0.1")
+      });
+
+    Assert.assertEquals(
+      "Find latest build-tools folder should return 25.0.1",
+      AndroidSdk.findLatestBuildToolsFolder(mockBuildToolsHome).getAbsolutePath(),
+      new File("/", "25.0.1").getAbsolutePath());
+  }
+}


### PR DESCRIPTION
This PR fixes the way we determine which is the latest build-tools/platform version. The previous implementation's could break if certain folders were present in an Android SDK installation, plus sorting by file name was just wrong