### PR TITLE
Add monitoring of instrumentation process output

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -13,6 +13,7 @@
  */
 package io.selendroid.standalone.android;
 
+import io.selendroid.standalone.android.InstrumentationProcessListener;
 import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.common.device.DeviceTargetPlatform;
 import io.selendroid.standalone.exceptions.AndroidDeviceException;
@@ -32,7 +33,7 @@ public interface AndroidDevice {
   public void install(AndroidApp app) throws AndroidSdkException;
 
   public boolean isInstalled(String appBasePackage) throws AndroidSdkException;
-  
+
   public boolean isInstalled(AndroidApp app) throws AndroidSdkException;
 
   public void uninstall(AndroidApp app) throws AndroidSdkException;
@@ -98,4 +99,7 @@ public interface AndroidDevice {
   public String getAPITargetType();
 
   public void unlockScreen() throws AndroidDeviceException;
+
+  public void addInstrumentationProcessListener(
+    InstrumentationProcessListener listener);
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessListener.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessListener.java
@@ -1,0 +1,6 @@
+package io.selendroid.standalone.android;
+
+public interface InstrumentationProcessListener {
+  void onInstrumentationProcessComplete(String output);
+  void onInstrumentationProcessFailed(String output, Exception error);
+}

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessOutput.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessOutput.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+ package io.selendroid.standalone.android;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class InstrumentationProcessOutput {
+  private String errorMessage;
+  private String shortMessage;
+  private String longMessage;
+  private String fullOutput;
+
+  private static final String REGULAR_CRASH_MESSAGE = "Process crashed.";
+  private static final String NATIVE_CRASH_MESSAGE = "Native crash";
+
+  private static final String SHORT_MESSAGE_REGEX =
+    "INSTRUMENTATION_RESULT: shortMsg=(.+)";
+  private static final String LONG_MESSAGE_REGEX =
+    "INSTRUMENTATION_RESULT: longMsg=(.+)";
+  private static final String ERROR_MESSAGE_REGEX =
+    "INSTRUMENTATION_STATUS: Error=(.+)";
+
+  public static InstrumentationProcessOutput parse(String output) {
+    Matcher shortMessageMatcher =
+      Pattern
+        .compile(SHORT_MESSAGE_REGEX)
+        .matcher(output);
+    Matcher longMessageMatcher =
+      Pattern
+        .compile(LONG_MESSAGE_REGEX)
+        .matcher(output);
+    Matcher errorMessageMatcher =
+      Pattern
+        .compile(ERROR_MESSAGE_REGEX)
+        .matcher(output);
+
+    String shortMessage;
+    if (shortMessageMatcher.find()) {
+      shortMessage = shortMessageMatcher.group(1);
+    } else {
+      shortMessage = null;
+    }
+
+    String longMessage;
+    if (longMessageMatcher.find()) {
+      longMessage = longMessageMatcher.group(1);
+    } else {
+      longMessage = null;
+    }
+
+    String errorMessage;
+    if (errorMessageMatcher.find()) {
+      errorMessage = errorMessageMatcher.group(1);
+    } else {
+      errorMessage = null;
+    }
+
+    return (new InstrumentationProcessOutput())
+      .setFullOutput(output)
+      .setShortMessage(shortMessage)
+      .setLongMessage(longMessage)
+      .setErrorMessage(errorMessage);
+  }
+
+  public boolean isAppCrash() {
+    return isRegularAppCrash() || isNativeCrash();
+  }
+
+  public boolean isRegularAppCrash() {
+    return REGULAR_CRASH_MESSAGE.equals(shortMessage);
+  }
+
+  public boolean isNativeCrash() {
+    return NATIVE_CRASH_MESSAGE.equals(shortMessage);
+  }
+
+  public String getMessage() {
+    if (isNativeCrash()) {
+      return longMessage;
+    }
+    if (isRegularAppCrash()) {
+      return shortMessage;
+    }
+
+    if (errorMessage != null) {
+      return errorMessage;
+    } else if (shortMessage != null) {
+      String message = shortMessage;
+      if (longMessage != null) {
+        message += "\n" + longMessage;
+      }
+      return message;
+    }
+
+    return fullOutput;
+  }
+
+  public String getFullOutput() {
+    return fullOutput;
+  }
+
+  private InstrumentationProcessOutput() {
+  }
+
+  private InstrumentationProcessOutput setFullOutput(String fullOutput) {
+    this.fullOutput = fullOutput;
+    return this;
+  }
+
+  private InstrumentationProcessOutput setShortMessage(String shortMessage) {
+    this.shortMessage = shortMessage;
+    return this;
+  }
+
+  private InstrumentationProcessOutput setLongMessage(String longMessage) {
+    this.longMessage = longMessage;
+    return this;
+  }
+
+  private InstrumentationProcessOutput setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+    return this;
+  }
+}

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -279,12 +279,7 @@ public abstract class AbstractDevice implements AndroidDevice {
       argList.add("io.selendroid." + aut.getBasePackage() + "/io.selendroid.server.SelendroidInstrumentation");
     }
 
-    String[] args = argList.toArray(new String[argList.size()]);
-    if (capabilities.getUseJUnitBootstrap()) {
-      runInstrumentCommandWithJUnitBootstrap(args);
-    } else {
-      runInstrumentCommand(args);
-    }
+    runInstrumentCommand(argList.toArray(new String[argList.size()]));
 
     forwardSelendroidPort(port);
 
@@ -293,7 +288,7 @@ public abstract class AbstractDevice implements AndroidDevice {
     }
   }
 
-  private void runInstrumentCommandWithJUnitBootstrap(String[] args) {
+  private void runInstrumentCommand(String[] args) {
     CommandLine command = adbCommand(ObjectArrays.concat(new String[]{"shell", "am", "instrument", "-w"}, args, String.class));
 
     final ShellCommand.PrintingLogOutputStream os = new ShellCommand.PrintingLogOutputStream();
@@ -316,32 +311,6 @@ public abstract class AbstractDevice implements AndroidDevice {
       });
     } catch(Exception e) {
       throw new SelendroidException(e);
-    }
-  }
-
-  private void runInstrumentCommand(String[] args) {
-    CommandLine command = adbCommand(ObjectArrays.concat(new String[]{"shell", "am", "instrument"}, args, String.class));
-    String result = executeCommandQuietly(command);
-    if (result.contains("FAILED")) {
-      String genericMessage = "Could not start the app under test using instrumentation.";
-      String detailedMessage;
-      try {
-        // Try again, waiting for instrumentation to finish. This way we'll get more error output.
-        String[] instrumentCmd =
-                ObjectArrays.concat(new String[]{"shell", "am", "instrument", "-w"}, args, String.class);
-        CommandLine getDetailedErrorCommand = adbCommand(instrumentCmd);
-        String detailedResult = executeCommandQuietly(getDetailedErrorCommand);
-        if (detailedResult.contains("package")) {
-          detailedMessage =
-                  genericMessage + " Is the correct app under test installed? Read the details below:\n" + detailedResult;
-        } else {
-          detailedMessage = genericMessage + " Read the details below:\n" + detailedResult;
-        }
-      } catch (Exception e) {
-        // Can't get detailed results
-        throw new SelendroidException(genericMessage, e);
-      }
-      throw new SelendroidException(detailedMessage);
     }
   }
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/AbstractDevice.java
@@ -355,7 +355,10 @@ public abstract class AbstractDevice implements AndroidDevice {
     try {
       response = httpClient.execute(request);
     } catch (Exception e) {
-      log.info("Can't connect to Selendroid server, assuming it is not running.");
+      log.log(
+        Level.INFO,
+        "Can't connect to Selendroid server, assuming it is not running.",
+        e);
       return false;
     }
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/ProxyToDeviceHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/ProxyToDeviceHandler.java
@@ -115,15 +115,6 @@ public class ProxyToDeviceHandler extends BaseSelendroidStandaloneHandler {
               System.out.println(le.getMessage());
             }
           }
-
-          if (e instanceof SocketException) {
-            return respondWithServerOnDeviceUnreachable(sessionId, session.getDevice());
-          } else if (e instanceof NoHttpResponseException) {
-            return respondWithServerOnDeviceUnreachable(sessionId, session.getDevice());
-          } else {
-            return respondWithFailure(sessionId, new SelendroidException(
-                "Unexpected error communicating with selendroid server on the device", e));
-          }
         } else {
           log.log(Level.SEVERE, "Failed to proxy request to Selendroid Server, retrying.", e);
         }
@@ -181,28 +172,6 @@ public class ProxyToDeviceHandler extends BaseSelendroidStandaloneHandler {
       sessionId,
       new SelendroidException(
         message + "\nOutput from instrumentation process:\n" + output));
-  }
-
-  /**
-   * selendroid-server can't be reached and there is no crash log file.
-   */
-  private SelendroidResponse respondWithServerOnDeviceUnreachable(String sessionId, AndroidDevice device)
-      throws JSONException {
-    String message =
-        "The selendroid server on the device became unreachable and there is no crash log from Android's " +
-        "uncaught exception handler. This can mean:\n" +
-        "- The test is trying to use a driver associated to a process that has finished " +
-        "(has the app been killed by the test?)\n" +
-        "- The app has been killed by the OS abruptly or there was a native crash (look at logcat)";
-    try {
-      String psOutput = device.listRunningThirdPartyProcesses();
-      if (!Strings.isNullOrEmpty(psOutput)) {
-        message += "\nCurrently running processes excluding system processes (via 'adb shell ps'):\n" + psOutput;
-      }
-    } catch (Exception e) {
-      message += "\nCould not get list of running processes: " + e.getMessage();
-    }
-    return respondWithFailure(sessionId, new SelendroidException(message));
   }
 
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/ActiveSession.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/ActiveSession.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -16,6 +16,7 @@ package io.selendroid.standalone.server.model;
 import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.standalone.android.AndroidApp;
 import io.selendroid.standalone.android.AndroidDevice;
+import io.selendroid.standalone.android.InstrumentationProcessListener;
 
 import java.util.Timer;
 
@@ -28,6 +29,10 @@ public class ActiveSession {
   private boolean invalid = false;
   private final Timer stopSessionTimer = new Timer(true);
 
+  private boolean instrumentationProcessFinished = false;
+  private Exception instrumentationProcessError;
+  private String instrumentationProcessOutput;
+
   ActiveSession(String sessionId, SelendroidCapabilities desiredCapabilities, AndroidApp aut,
       AndroidDevice device, int selendroidPort, SelendroidStandaloneDriver driver) {
     this.selendroidServerPort = selendroidPort;
@@ -37,6 +42,24 @@ public class ActiveSession {
     this.desiredCapabilities = desiredCapabilities;
     stopSessionTimer.schedule(new SessionTimeoutTask(driver, sessionId), driver
         .getSelendroidConfiguration().getSessionTimeoutMillis());
+    this.device.addInstrumentationProcessListener(
+      new InstrumentationProcessListener() {
+        @Override
+        public void onInstrumentationProcessComplete(String output) {
+          instrumentationProcessFinished = true;
+          instrumentationProcessOutput = output;
+          instrumentationProcessError = null;
+        }
+
+        @Override
+        public void onInstrumentationProcessFailed(
+          String output,
+          Exception error) {
+          instrumentationProcessFinished = true;
+          instrumentationProcessOutput = output;
+          instrumentationProcessError = error;
+        }
+      });
   }
 
   @Override
@@ -93,6 +116,19 @@ public class ActiveSession {
   public void stopSessionTimer() {
     stopSessionTimer.cancel();
   }
+
+  public boolean instrumentationProcessFinished() {
+    return instrumentationProcessFinished;
+  }
+
+  public String getInstrumentationProcessOutput() {
+    return instrumentationProcessOutput;
+  }
+
+  public Exception getInstrumentationProcessError() {
+    return instrumentationProcessError;
+  }
+
 
   @Override
   public String toString() {

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -14,6 +14,7 @@
 package io.selendroid.standalone.server.model;
 
 import com.beust.jcommander.internal.Lists;
+import com.google.common.base.Function;
 import io.netty.handler.codec.http.HttpMethod;
 import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.server.common.ServerDetails;
@@ -26,6 +27,7 @@ import io.selendroid.standalone.android.AndroidDevice;
 import io.selendroid.standalone.android.AndroidEmulator;
 import io.selendroid.standalone.android.AndroidSdk;
 import io.selendroid.standalone.android.DeviceManager;
+import io.selendroid.standalone.android.InstrumentationProcessListener;
 import io.selendroid.standalone.android.impl.DefaultAndroidEmulator;
 import io.selendroid.standalone.android.impl.DefaultDeviceManager;
 import io.selendroid.standalone.android.impl.DefaultHardwareDevice;
@@ -44,6 +46,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.remote.BrowserType;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.File;
@@ -57,9 +62,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.concurrent.TimeUnit;
 
-public class SelendroidStandaloneDriver implements ServerDetails {
-
+public class SelendroidStandaloneDriver
+  implements ServerDetails, InstrumentationProcessListener {
   public static final String WD_RESP_KEY_VALUE = "value";
   public static final String WD_RESP_KEY_STATUS = "status";
   public static final String WD_RESP_KEY_SESSION_ID = "sessionId";
@@ -78,6 +84,9 @@ public class SelendroidStandaloneDriver implements ServerDetails {
   private FolderMonitor folderMonitor = null;
   private SelendroidStandaloneDriverEventListener eventListener
       = new DummySelendroidStandaloneDriverEventListener();
+  private boolean instrumentationProcessFinished;
+  private String instrumentationProcessOutput;
+  private Exception instrumentationProcessError;
 
 
   public SelendroidStandaloneDriver(SelendroidConfiguration serverConfiguration)
@@ -278,6 +287,7 @@ public class SelendroidStandaloneDriver implements ServerDetails {
         // start the selendroid server on the device and make sure it's up
         eventListener.onBeforeDeviceServerStart();
         device.startSelendroid(app, port, desiredCapabilities);
+        device.addInstrumentationProcessListener(this);
         waitForServerStart(device);
         eventListener.onAfterDeviceServerStart();
 
@@ -338,26 +348,53 @@ public class SelendroidStandaloneDriver implements ServerDetails {
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("AndroidDriver")));
   }
 
-  private void waitForServerStart(AndroidDevice device) {
-    long startTimeout = serverConfiguration.getServerStartTimeout();
-    long timeoutEnd = System.currentTimeMillis() + startTimeout;
+  private void waitForServerStart(final AndroidDevice device) {
     log.info("Waiting for the Selendroid server to start.");
-    while (!device.isSelendroidRunning()) {
-      if (timeoutEnd >= System.currentTimeMillis()) {
-        try {
-          Thread.sleep(2000);
+
+    Wait<AndroidDevice> wait = new FluentWait<AndroidDevice>(device)
+      .withTimeout(
+        serverConfiguration.getServerStartTimeout(),
+        TimeUnit.MILLISECONDS);
+    try {
+      wait.until(new Function<AndroidDevice, Boolean>() {
+        @Override
+        public Boolean apply(AndroidDevice device) {
           String crashMessage = device.getCrashLog();
           if (!crashMessage.isEmpty()) {
             throw new AppCrashedException(crashMessage);
           }
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
+
+          if (instrumentationProcessFinished()) {
+            final String instrumentationOutput = getInstrumentationProcessOutput();
+            final Exception instrumentationError = getInstrumentationProcessError();
+            if (instrumentationError != null) {
+                throw new SelendroidException(
+                  "Failed to execute instrument command, output:\n" + instrumentationOutput,
+                  instrumentationError);
+            }
+
+            String message;
+            if (instrumentationOutput.contains("package")) {
+              message = "Could not start the app under test using instrumentation."
+                + " Is the correct app under test installed? Read the details below:\n"
+                + instrumentationOutput;
+            } else {
+              message = "Instrumentation process failed. See output:\n" + instrumentationOutput;
+            }
+
+            throw new SelendroidException(message);
+          }
+
+          return device.isSelendroidRunning();
         }
-      } else {
-        throw new SelendroidException("Selendroid server on the device didn't come up after "
-            + startTimeout / 1000 + "sec:");
-      }
+      });
+    } catch (TimeoutException e) {
+      throw new SelendroidException(
+        "Selendroid server didn't come up on the device after"
+        + serverConfiguration.getServerStartTimeout() / 1000
+        + " seconds");
     }
+
     log.info("Selendroid server has started.");
   }
 
@@ -647,5 +684,30 @@ public class SelendroidStandaloneDriver implements ServerDetails {
 
   public void setEventListener(SelendroidStandaloneDriverEventListener eventListener) {
     this.eventListener = eventListener;
+  }
+
+  private boolean instrumentationProcessFinished() {
+    return instrumentationProcessFinished;
+  }
+
+  private String getInstrumentationProcessOutput() {
+    return instrumentationProcessOutput;
+  }
+
+  private Exception getInstrumentationProcessError() {
+    return instrumentationProcessError;
+  }
+
+  @Override
+  public void onInstrumentationProcessComplete(String output) {
+    instrumentationProcessFinished = true;
+    instrumentationProcessOutput = output;
+  }
+
+  @Override
+  public void onInstrumentationProcessFailed(String output, Exception error) {
+    instrumentationProcessFinished = true;
+    instrumentationProcessOutput = output;
+    instrumentationProcessError = error;
   }
 }

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/InstrumentationProcessOutputTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/InstrumentationProcessOutputTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+ package io.selendroid.standalone.android;
+
+import java.lang.instrument.Instrumentation;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InstrumentationProcessOutputTest {
+
+  @Test
+  public void testNativeCrash() {
+    InstrumentationProcessOutput output = InstrumentationProcessOutput.parse(
+      "INSTRUMENTATION_RESULT: shortMsg=Native crash\n" +
+      "INSTRUMENTATION_RESULT: longMsg=Native crash: Segmentation fault\n" +
+      "INSTRUMENTATION_CODE: 0");
+
+    Assert.assertTrue(output.isAppCrash());
+    Assert.assertFalse(output.isRegularAppCrash());
+    Assert.assertTrue(output.isNativeCrash());
+    Assert.assertEquals("Native crash: Segmentation fault", output.getMessage());
+  }
+
+  @Test
+  public void testRegularCrash() {
+    InstrumentationProcessOutput output = InstrumentationProcessOutput.parse(
+      "INSTRUMENTATION_RESULT: shortMsg=Process crashed.\n"+
+      "INSTRUMENTATION_CODE: 0");
+
+    Assert.assertTrue(output.isAppCrash());
+    Assert.assertTrue(output.isRegularAppCrash());
+    Assert.assertFalse(output.isNativeCrash());
+    Assert.assertEquals("Process crashed.", output.getMessage());
+  }
+
+  @Test
+  public void testAppNotInstalled() {
+    InstrumentationProcessOutput output = InstrumentationProcessOutput.parse(
+      "INSTRUMENTATION_STATUS: Error=Unable to find instrumentation target package: com.foo\n" +
+      "INSTRUMENTATION_STATUS_CODE: -1");
+
+    Assert.assertFalse(output.isAppCrash());
+    Assert.assertEquals(
+      "Unable to find instrumentation target package: com.foo",
+      output.getMessage());
+  }
+
+  @Test
+  public void testOtherValidInstrumentationOutput() {
+    InstrumentationProcessOutput output = InstrumentationProcessOutput.parse(
+      "INSTRUMENTATION_RESULT: shortMsg=keyDispatchingTimedOut\n" +
+      "INSTRUMENTATION_RESULT: longMsg=Input dispatching timed out (Waiting because the touched window has not finished processing the input events that were previously delivered to it.)");
+
+    Assert.assertFalse(output.isAppCrash());
+    Assert.assertEquals(
+      "keyDispatchingTimedOut\n" +
+      "Input dispatching timed out (Waiting because the touched window has not finished processing the input events that were previously delivered to it.)",
+      output.getMessage());
+  }
+
+  @Test
+  public void testUnstructuredInstrumentationOutput() {
+    InstrumentationProcessOutput output = InstrumentationProcessOutput.parse(
+      "android.util.AndroidException: INSTRUMENTATION_FAILED: io.selendroid.com.facebook.orca/io.selendroid.server.SelendroidInstrumentation\n" +
+    	"at com.android.commands.am.Am.runInstrument(Am.java:865)\n" +
+    	"at com.android.commands.am.Am.onRun(Am.java:282)\n" +
+    	"at com.android.internal.os.BaseCommand.run(BaseCommand.java:47)\n" +
+    	"at com.android.commands.am.Am.main(Am.java:76)\n" +
+    	"at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)\n" +
+    	"at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:243)\n" +
+    	"at dalvik.system.NativeStart.main(Native Method)");
+
+    Assert.assertFalse(output.isAppCrash());
+    Assert.assertEquals(
+      "android.util.AndroidException: INSTRUMENTATION_FAILED: io.selendroid.com.facebook.orca/io.selendroid.server.SelendroidInstrumentation\n" +
+    	"at com.android.commands.am.Am.runInstrument(Am.java:865)\n" +
+    	"at com.android.commands.am.Am.onRun(Am.java:282)\n" +
+    	"at com.android.internal.os.BaseCommand.run(BaseCommand.java:47)\n" +
+    	"at com.android.commands.am.Am.main(Am.java:76)\n" +
+    	"at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)\n" +
+    	"at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:243)\n" +
+    	"at dalvik.system.NativeStart.main(Native Method)",
+      output.getMessage());
+  }
+}


### PR DESCRIPTION
This PR adds monitoring of the instrumentation process (the `am instrument` call) . Whenever the instrumentation process died in the middle of a session, we wouldn't be able to detect it other than the Selendroid server on the device becoming unresponsive which lead to unnecessary timeouts. With these changes, we can check whenever the instrumentation process for the session has finished and fail immediately. This allows us to:
- Not need to timeout whenever the AUT is not installed
- Have proper native crash detection
- Get rid of `Server on the device became unreachable` messages