### PR TITLE
Remove DefaultHardwareDevice getProp override

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultHardwareDevice.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2012-2014 eBay Software Foundation and selendroid committers.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -51,11 +51,6 @@ public class DefaultHardwareDevice extends AbstractDevice {
   }
 
   @Override
-  protected String getProp(String key) {
-    return device.getProperty(key);
-  }
-
-  @Override
   public DeviceTargetPlatform getTargetPlatform() {
     if (targetPlatform == null) {
       String version = getProp("ro.build.version.sdk");
@@ -96,7 +91,7 @@ public class DefaultHardwareDevice extends AbstractDevice {
     return "HardwareDevice [serial=" + serial + ", model=" + getModel() + ", targetVersion="
         + getTargetPlatform() + ", apiTargetType=" + apiTargetType + "]";
   }
-  
+
   public String getSerial() {
     return serial;
   }


### PR DESCRIPTION
Use AbstractDevice getProp (which uses adb shell getprop)

The ddmlib IDevice getProp version is sdk dependent