### PR TITLE
[standalone] Split local and remote port for server

### DIFF
--- a/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
+++ b/selendroid-common/src/main/java/io/selendroid/common/SelendroidCapabilities.java
@@ -65,6 +65,8 @@ public class SelendroidCapabilities extends DesiredCapabilities {
 
   public static final String USE_JUNIT_BOOTSTRAP = "useJUnitBootstrap";
 
+  public static final String USE_RANDOM_LOCAL_PORT = "useRandomLocalPort";
+
   public static SelendroidCapabilities empty() {
     return new SelendroidCapabilities(new HashMap<String, Object>());
   }
@@ -119,6 +121,11 @@ public class SelendroidCapabilities extends DesiredCapabilities {
   public boolean getUseJUnitBootstrap() {
     Boolean useJUnitRunner = getBooleanCapability(USE_JUNIT_BOOTSTRAP);
     return useJUnitRunner != null ? useJUnitRunner : false;
+  }
+
+  public boolean getUseRandomLocalPort() {
+    Boolean useRandomLocalPort = getBooleanCapability(USE_RANDOM_LOCAL_PORT);
+    return useRandomLocalPort != null ? useRandomLocalPort : false;
   }
 
   public String getPlatformName() {
@@ -254,6 +261,10 @@ public class SelendroidCapabilities extends DesiredCapabilities {
 
   public void setUseJunitRunner(Boolean useJUnitRunner) {
     setCapability(USE_JUNIT_BOOTSTRAP, useJUnitRunner);
+  }
+
+  public void setUseRandomLocalPort(boolean useRandomLocalPort) {
+    setCapability(USE_RANDOM_LOCAL_PORT, useRandomLocalPort);
   }
 
   public void setLocale(String locale) {

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/AndroidDevice.java
@@ -40,7 +40,7 @@ public interface AndroidDevice {
 
   public boolean start(AndroidApp app) throws AndroidSdkException;
 
-  public void forwardPort(int local, int remote);
+  public int forwardPort(int local, int remote);
 
   public void clearUserData(AndroidApp app) throws AndroidSdkException;
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulator.java
@@ -245,7 +245,6 @@ public class DefaultAndroidEmulator extends AbstractDevice implements AndroidEmu
   }
 
   public void setSerial(int port) {
-    this.port = port;
     serial = EMULATOR_SERIAL_PREFIX + port;
   }
 

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/ActiveSession.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/ActiveSession.java
@@ -79,7 +79,7 @@ public class ActiveSession {
   }
 
   public int getSelendroidServerPort() {
-    return selendroidServerPort;
+    return getDevice().getSelendroidsPort();
   }
 
   public SelendroidCapabilities getDesiredCapabilities() {

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/SelendroidStandaloneDriver.java
@@ -304,7 +304,7 @@ public class SelendroidStandaloneDriver
 
         // create the new session on the device server
         RemoteWebDriver driver =
-          new RemoteWebDriver(new URL("http://localhost:" + port + "/wd/hub"), desiredCapabilities);
+          new RemoteWebDriver(new URL("http://localhost:" + device.getSelendroidsPort() + "/wd/hub"), desiredCapabilities);
         String sessionId = driver.getSessionId().toString();
         SelendroidCapabilities requiredCapabilities =
           new SelendroidCapabilities(driver.getCapabilities().asMap());
@@ -402,7 +402,7 @@ public class SelendroidStandaloneDriver
       });
     } catch (TimeoutException e) {
       throw new SelendroidException(
-        "Selendroid server didn't come up on the device after"
+        "Selendroid server didn't come up on the device after "
         + serverConfiguration.getServerStartTimeout() / 1000
         + " seconds");
     }


### PR DESCRIPTION
Split local a remote ports used for proxying requests to the device and add a capability to enable using a random local port for forwarding