### PR TITLE
Stop polling crash logs in ProxyToDeviceHandler

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessOutput.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessOutput.java
@@ -191,7 +191,9 @@ public class InstrumentationProcessOutput {
           new Function<AndroidDevice, String>() {
             @Override
             public String apply(AndroidDevice device) {
-              return device.getCrashLog();
+              // getCrashLog is not nullable
+              String crashLog = device.getCrashLog();
+              return crashLog.isEmpty() ? null : crashLog;
             }
           }
         );

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessOutput.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/android/InstrumentationProcessOutput.java
@@ -42,12 +42,15 @@ public class InstrumentationProcessOutput {
     "INSTRUMENTATION_STATUS: Error=(.+)";
 
   private static final long CRASH_LOG_TIMEOUT_MS = 2000;
+  public static final String CRASH_LOG_TIMEOUT_ERROR_MESSAGE =
+    "Failed to get stacktrace, see Logcat for more details";
 
   public static final String INSTRUMENTATION_PROCESS_FAILED_ERROR_MESSAGE =
     "Instrumentation process failed";
   public static final String APP_NOT_INSTALLED_ERROR_MESSAGE =
     "Could not start the app under test using instrumentation. " +
     "Is the correct app under test installed? Read the details below";
+
 
   public static InstrumentationProcessOutput parse(String output) {
     Matcher shortMessageMatcher =
@@ -154,24 +157,6 @@ public class InstrumentationProcessOutput {
   public static final SelendroidException getInstrumentationProcessError(
     InstrumentationProcessOutput instrumentationOutput,
     final AndroidDevice device) {
-    if (!instrumentationOutput.isAppCrash()) {
-      if (instrumentationOutput
-          .getMessage()
-          .contains("Unable to find instrumentation target package")) {
-        return new SelendroidException(
-          APP_NOT_INSTALLED_ERROR_MESSAGE +
-          ":\n" +
-          instrumentationOutput.getFullOutput());
-      }
-
-      return new SelendroidException(
-        INSTRUMENTATION_PROCESS_FAILED_ERROR_MESSAGE +
-        ": " +
-        instrumentationOutput.getMessage() +
-        "\nSee full output for more details:\n" +
-        instrumentationOutput.getFullOutput());
-    }
-
     if (instrumentationOutput.isNativeCrash()) {
       return new AppCrashedException(
         INSTRUMENTATION_PROCESS_FAILED_ERROR_MESSAGE +
@@ -180,10 +165,44 @@ public class InstrumentationProcessOutput {
         "\nSee logcat for more details");
     }
 
-    // In case of an app crash, the instrumentation process can be terminated
-    // before we actually have the crash logs, so we have to wait until we do
+    if (instrumentationOutput.isRegularAppCrash()) {
+      // There's a race condition between the instrumentation process
+      // terminating and the crash logs being written on the device
+      // so we wait a certain time in order to be able to provide a stacktrace
+      // for the crash
+      String errorMessage = waitForCrashLog(device);
+      if (errorMessage == null) {
+        errorMessage = INSTRUMENTATION_PROCESS_FAILED_ERROR_MESSAGE +
+          ": " +
+          instrumentationOutput.getMessage() + "\n" +
+          CRASH_LOG_TIMEOUT_ERROR_MESSAGE;
+      }
+
+      return new AppCrashedException(errorMessage);
+    }
+
+    // Special case for when the app under test is not installed
+    if (instrumentationOutput
+        .getMessage()
+        .contains("Unable to find instrumentation target package")) {
+      return new SelendroidException(
+        APP_NOT_INSTALLED_ERROR_MESSAGE +
+        ":\n" +
+        instrumentationOutput.getFullOutput());
+    }
+
+    return new SelendroidException(
+      INSTRUMENTATION_PROCESS_FAILED_ERROR_MESSAGE +
+      ": " +
+      instrumentationOutput.getMessage() +
+      "\nSee full output for more details:\n" +
+      instrumentationOutput.getFullOutput());
+
+  }
+
+  private static String waitForCrashLog(final AndroidDevice device) {
     try {
-      String crashLogs = (new FluentWait<AndroidDevice>(device))
+      return (new FluentWait<AndroidDevice>(device))
         .withTimeout(
           CRASH_LOG_TIMEOUT_MS,
           TimeUnit.MILLISECONDS)
@@ -197,14 +216,8 @@ public class InstrumentationProcessOutput {
             }
           }
         );
-
-      return new AppCrashedException(crashLogs);
     } catch (TimeoutException e) {
-      return new AppCrashedException(
-        INSTRUMENTATION_PROCESS_FAILED_ERROR_MESSAGE +
-        ": " +
-        instrumentationOutput.getMessage() +
-        "\nSee logcat for more details");
+      return null;
     }
   }
 }

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/ProxyToDeviceHandler.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/handler/ProxyToDeviceHandler.java
@@ -97,12 +97,6 @@ public class ProxyToDeviceHandler extends BaseSelendroidStandaloneHandler {
         @Override
         public Response apply(AndroidDevice device) {
           try {
-            // Check if the app crashed in the middle of the request
-            String crashLog = device.getCrashLog();
-            if (!crashLog.isEmpty()) {
-              return respondWithFailure(sessionId, new AppCrashedException(crashLog));
-            }
-
             // Check if the instrumentation process died in the middle of the request
             if (session.instrumentationProcessFinished()) {
               return respondWithInstrumentationProcessFinished(
@@ -133,12 +127,6 @@ public class ProxyToDeviceHandler extends BaseSelendroidStandaloneHandler {
         }
       });
     } catch (TimeoutException e) {
-      // Check for regular app crashes first
-      String crashLog = device.getCrashLog();
-      if (!crashLog.isEmpty()) {
-        return respondWithFailure(sessionId, new AppCrashedException(crashLog));
-      }
-
       // Check if we timed out because of the instrumentation process dying
       if (session.instrumentationProcessFinished()) {
         return respondWithInstrumentationProcessFinished(

--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/ActiveSession.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/server/model/ActiveSession.java
@@ -19,6 +19,7 @@ import io.selendroid.standalone.android.AndroidDevice;
 import io.selendroid.standalone.android.InstrumentationProcessListener;
 
 import java.util.Timer;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ActiveSession {
   private final String sessionId;
@@ -29,7 +30,7 @@ public class ActiveSession {
   private boolean invalid = false;
   private final Timer stopSessionTimer = new Timer(true);
 
-  private boolean instrumentationProcessFinished = false;
+  private AtomicBoolean instrumentationProcessFinished = new AtomicBoolean(false);
   private Exception instrumentationProcessError;
   private String instrumentationProcessOutput;
 
@@ -46,7 +47,7 @@ public class ActiveSession {
       new InstrumentationProcessListener() {
         @Override
         public void onInstrumentationProcessComplete(String output) {
-          instrumentationProcessFinished = true;
+          instrumentationProcessFinished.set(true);
           instrumentationProcessOutput = output;
           instrumentationProcessError = null;
         }
@@ -55,7 +56,7 @@ public class ActiveSession {
         public void onInstrumentationProcessFailed(
           String output,
           Exception error) {
-          instrumentationProcessFinished = true;
+          instrumentationProcessFinished.set(true);
           instrumentationProcessOutput = output;
           instrumentationProcessError = error;
         }
@@ -118,7 +119,7 @@ public class ActiveSession {
   }
 
   public boolean instrumentationProcessFinished() {
-    return instrumentationProcessFinished;
+    return instrumentationProcessFinished.get();
   }
 
   public String getInstrumentationProcessOutput() {

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/InstrumentationProcessOutputTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/InstrumentationProcessOutputTest.java
@@ -79,12 +79,13 @@ public class InstrumentationProcessOutputTest {
     Assert.assertEquals("Process crashed.", output.getMessage());
 
     AndroidDevice device = mock(DefaultAndroidEmulator.class);
-    when(device.getCrashLog()).thenReturn(null);
+    when(device.getCrashLog()).thenReturn("");
     Throwable error = InstrumentationProcessOutput
       .getInstrumentationProcessError(output, device);
 
     Assert.assertTrue(error instanceof AppCrashedException);
-    Assert.assertTrue(error.getMessage().contains(""));
+    Assert.assertTrue(error.getMessage().contains(
+      InstrumentationProcessOutput.CRASH_LOG_TIMEOUT_ERROR_MESSAGE));
   }
 
   @Test

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/InstrumentationProcessOutputTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/InstrumentationProcessOutputTest.java
@@ -84,7 +84,7 @@ public class InstrumentationProcessOutputTest {
       .getInstrumentationProcessError(output, device);
 
     Assert.assertTrue(error instanceof AppCrashedException);
-    Assert.assertTrue(error.getMessage().contains(output.getMessage()));
+    Assert.assertTrue(error.getMessage().contains(""));
   }
 
   @Test


### PR DESCRIPTION
We were checking the device's crash log multiple times for every request made to `ProxyToDeviceHandler` which can be very expensive, specially when running on remote emulators.

The main reason for this was that there is a race condition between the instrumentation process being terminated (which we're monitoring in a separate thread) and us writing to the crash log. However, we were supposedly getting around that race condition by waiting for the crash log to be written whenever the instrumentation process output detects a Java crash. This pull request:

- Fixes a bug in the logic for waiting for the crash log be written which made it so that we weren't really waiting
- Adds better error messages to distinguish when we can and cannot get the crash log
- Remove the crash log checks from ProxyToDeviceHandler