### PR TITLE
fix(SelendroidWebDriver): use evaluateJavascript on KitKat+ to bypass page CSP (#970)

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/SelendroidWebDriver.java
@@ -236,7 +236,16 @@ public class SelendroidWebDriver {
         // switch back to NATIVE_APP and then to the webview again, this will allow
         // selendroid to wrap the 'new' chromeClient set by the AUT.
         webview.setWebChromeClient(chromeClient);
-        webview.loadUrl("javascript:" + script);
+        // Issue #970: pages with strict Content-Security-Policy (e.g. Cordova
+        // apps shipping `default-src 'self'`) reject loadUrl("javascript:...")
+        // as an `unsafe-eval` violation. WebView.evaluateJavascript is a
+        // separate native bridge and is not subject to the page's CSP, so it
+        // works on those pages. Fall back to the legacy path on pre-KitKat.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+          webview.evaluateJavascript(script, null);
+        } else {
+          webview.loadUrl("javascript:" + script);
+        }
       }
     });
     long timeout = System.currentTimeMillis() + scriptTimeout;


### PR DESCRIPTION
## Use `WebView.evaluateJavascript` to bypass page CSP (#970)

Resolves #970 - Selendroid commands fail with `'unsafe-eval' is not an allowed source of script`.

### Why it fails today

`SelendroidWebDriver.executeJavascriptInWebView()` runs:

```java
webview.loadUrl("javascript:" + script);
```

Android implements `loadUrl("javascript:...")` through the page's own
JavaScript engine, so the call is subject to the page's
Content-Security-Policy. Pages that ship a strict CSP without
`'unsafe-eval'` reject every selendroid command. The reporter's app and
every reproduction in the thread (Cordova / Ionic webviews with
`default-src 'self'`) are exactly that case.

### Fix

`selendroid-server/.../SelendroidWebDriver.java`:

In `executeJavascriptInWebView()`, replace the unconditional
`loadUrl("javascript:" + script)` with:

```java
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
  webview.evaluateJavascript(script, null);
} else {
  webview.loadUrl("javascript:" + script);
}
```

`WebView.evaluateJavascript` (API 19+) is implemented as a separate
native bridge and is not subject to the page's CSP, so it succeeds
against pages that block `unsafe-eval`. The result-plumbing
(`alert('selendroid<...>:' + ...)` -> `chromeClient.onJsAlert`) keeps
working because `alert()` still fires from the main world.

The legacy `loadUrl` branch is kept for pre-KitKat devices that
selendroid still supports.
