### PR TITLE
fix(#267): clear latched SHIFT on Android 4.0 WebView in InstrumentedKeySender

### DIFF
--- a/selendroid-server/src/main/java/io/selendroid/server/android/InstrumentedKeySender.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/android/InstrumentedKeySender.java
@@ -17,6 +17,8 @@ package io.selendroid.server.android;
 import io.selendroid.server.common.exceptions.SelendroidException;
 import io.selendroid.server.model.Keyboard;
 import android.app.Instrumentation;
+import android.os.Build;
+import android.os.SystemClock;
 import android.view.KeyEvent;
 import io.selendroid.server.util.SelendroidLogger;
 
@@ -83,6 +85,7 @@ public class InstrumentedKeySender implements KeySender {
         }
         SelendroidLogger.debug("Send keys, sending special key code");
         instrumentation.sendKeyDownUpSync(keyCode);
+        clearLatchedShiftOnAndroid40();
         currentIndex++;
       } else {
         // There is at least one "normal" character, that is a character
@@ -91,10 +94,47 @@ public class InstrumentedKeySender implements KeySender {
         // as possible in a single String.
         int nextSpecialKey = indexOfSpecialKey(text, currentIndex);
         SelendroidLogger.debug("Send keys, sending string");
-        instrumentation.sendStringSync(text.subSequence(currentIndex, nextSpecialKey).toString());
+        // Issue #267: on Android 4.0 (API 14-15) the system WebView leaks the
+        // SHIFT meta state between successive synthesized KeyEvents, turning
+        // mixed-case input into all-caps. Sending each character via its own
+        // sendStringSync() call, followed by an explicit SHIFT clear, lets us
+        // reset the latched modifier between characters on the affected
+        // platforms while keeping the original batched fast path everywhere
+        // else.
+        if (isAndroid40()) {
+          String chunk = text.subSequence(currentIndex, nextSpecialKey).toString();
+          for (int i = 0; i < chunk.length(); i++) {
+            instrumentation.sendStringSync(String.valueOf(chunk.charAt(i)));
+            clearLatchedShiftOnAndroid40();
+          }
+        } else {
+          instrumentation.sendStringSync(text.subSequence(currentIndex, nextSpecialKey).toString());
+        }
         currentIndex = nextSpecialKey;
       }
     }
+  }
+
+  private static boolean isAndroid40() {
+    return Build.VERSION.SDK_INT == Build.VERSION_CODES.ICE_CREAM_SANDWICH
+        || Build.VERSION.SDK_INT == Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1;
+  }
+
+  /**
+   * Workaround for issue #267. The Android 4.0 WebView fails to clear the SHIFT
+   * meta state after a synthesized KeyEvent, so subsequent characters are typed
+   * in upper case. Injecting an explicit SHIFT_LEFT ACTION_UP with a zeroed
+   * meta state forces the WebView's input connection to drop any latched SHIFT
+   * before the next character arrives. This is a no-op on every other API
+   * level.
+   */
+  private void clearLatchedShiftOnAndroid40() {
+    if (!isAndroid40()) {
+      return;
+    }
+    long eventTime = SystemClock.uptimeMillis();
+    instrumentation.sendKeySync(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP,
+        KeyEvent.KEYCODE_SHIFT_LEFT, 0, 0));
   }
 
   private class KeyboardImpl implements Keyboard {

--- a/selendroid-server/src/main/java/io/selendroid/server/model/Keyboard.java
+++ b/selendroid-server/src/main/java/io/selendroid/server/model/Keyboard.java
@@ -19,7 +19,32 @@ package io.selendroid.server.model;
 /**
  * Interface representing basic keyboard operations.
  *
+ * <h2>Known platform quirks</h2>
+ * <ul>
+ *   <li><b>Android 4.0 WebView (issue #267).</b> Sending characters to a
+ *       WebView text input on Android 4.0 (API 14 to 15) yields an
+ *       all-uppercase result because the system WebView leaks the SHIFT
+ *       meta state between consecutive synthesized {@code KeyEvent}s. The
+ *       behaviour does not appear on Android 2.3, 4.2 or 4.3. The bundled
+ *       {@code InstrumentedKeySender} works around the bug by sending one
+ *       character at a time and injecting an explicit {@code SHIFT_LEFT}
+ *       {@code ACTION_UP} with a zeroed meta state between characters on
+ *       API 14 and 15 only; other platforms keep the original batched
+ *       fast path. {@code adb shell input text} via the
+ *       {@code AdbSendText} handler in selendroid-standalone remains a
+ *       valid alternative for tests that prefer to bypass the WebView
+ *       input pipeline entirely.</li>
+ * </ul>
  */
 public interface Keyboard {
+  /**
+   * Type the given key sequence into the focused element.
+   *
+   * @param keysToSend characters to type, in order. Implementations are
+   *                   expected to clear any previously latched modifier
+   *                   meta state (SHIFT, ALT, CTRL) between characters so
+   *                   that mixed-case input is preserved. See the class
+   *                   javadoc for the Android 4.0 WebView caveat.
+   */
   void sendKeys(CharSequence... keysToSend);
 }


### PR DESCRIPTION
Closes #267.

## Issue recap

On Android 4.0 (API 14 to 15) emulators, sending text to a WebView input via the
standard `sendKeys` path produces an all-uppercase result. The same code path
works correctly on Android 2.3, 4.2 and 4.3. The reporter confirmed the bug on
both Mac OS X and Ubuntu hosts, with and without HAXM, so the fault is in the
Android 4.0 system WebView itself: it does not clear the SHIFT meta state
between consecutive synthesized `KeyEvent` objects, which leaves the next
character latched in upper case.

## Fix

Patch `InstrumentedKeySender.send()` to detect API 14 and API 15 at runtime and,
on those releases only, work around the WebView's leaked SHIFT meta state:

1. Send each "normal" character through its own `Instrumentation.sendStringSync`
   call instead of batching the whole run, so the input pipeline is exercised
   one character at a time.
2. After every `sendStringSync` and after every `sendKeyDownUpSync`, inject an
   explicit `KEYCODE_SHIFT_LEFT` `ACTION_UP` event with `metaState = 0`. This
   forces the WebView's input connection to drop any latched SHIFT before the
   next character arrives.
3. On every other API level, keep the original batched fast path untouched, so
   throughput on supported platforms is unchanged.

The detection is gated on `Build.VERSION.SDK_INT == ICE_CREAM_SANDWICH ||
Build.VERSION.SDK_INT == ICE_CREAM_SANDWICH_MR1`, so the new code is a strict
no-op on every release that did not exhibit the bug.

The `Keyboard` SPI javadoc is also updated to document the quirk and the
in-tree workaround so any future implementer cannot accidentally reintroduce
the same shape of bug, and so that downstream maintainers know they no longer
need to route 4.0 traffic through `adb shell input text` (though that remains
a valid alternative).

## Files changed

* `selendroid-server/src/main/java/io/selendroid/server/android/InstrumentedKeySender.java`
  &mdash; runtime workaround scoped to API 14/15.
* `selendroid-server/src/main/java/io/selendroid/server/model/Keyboard.java`
  &mdash; SPI javadoc records the quirk, the contract for clearing modifier
  meta state between characters, and the bundled fix.

## Validation

* Mixed-case input (`Test string`) sent through `WebElement#sendKeys` now
  produces `Test string` on the API 15 x86 emulator that originally
  reproduced #267, instead of `TEST STRING`.
* The new code path is only entered when `Build.VERSION.SDK_INT` matches API
  14 or 15, so behaviour on Android 2.3 and 4.2+ is byte-for-byte identical to
  master.
* The `Keyboard` interface signature is preserved, so binary compatibility
  with existing implementers is unaffected.
