### PR TITLE
feat(#106): expose -additionalSelendroidServerPorts so multiple instrumentation servers can run in parallel

### DIFF
--- a/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
+++ b/selendroid-standalone/src/main/java/io/selendroid/standalone/SelendroidConfiguration.java
@@ -61,6 +61,12 @@ public class SelendroidConfiguration {
       names = {"-reuseSelendroidServerPort"})
   private boolean reuseSelendroidServerPort = false;
 
+  @Parameter(
+      description = "comma-separated list of additional ports the standalone server may use "
+          + "to host extra instrumentation servers in parallel. See issue #106 for context.",
+      names = {"-additionalSelendroidServerPorts"})
+  private String additionalSelendroidServerPortsRaw = "";
+
   @Parameter(description = "The file of the keystore to be used", names = {"-keystore"})
   private String keystore = null;
 
@@ -238,6 +244,41 @@ public class SelendroidConfiguration {
 
   public int getSelendroidServerPort() {
     return selendroidServerPort;
+  }
+
+  /**
+   * Parsed view of the comma-separated -additionalSelendroidServerPorts value.
+   *
+   * @return the list of additional ports declared on the command line, or an
+   *         empty list when none were provided. Tokens that are not valid
+   *         positive integers are silently skipped so a typo in the option
+   *         does not crash standalone startup.
+   */
+  public List<Integer> getAdditionalSelendroidServerPorts() {
+    final List<Integer> parsed = new ArrayList<Integer>();
+    if (additionalSelendroidServerPortsRaw == null
+        || additionalSelendroidServerPortsRaw.trim().isEmpty()) {
+      return parsed;
+    }
+    for (final String token : additionalSelendroidServerPortsRaw.split(",")) {
+      final String trimmed = token.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      try {
+        final int port = Integer.parseInt(trimmed);
+        if (port > 0 && port < 65536 && port != selendroidServerPort) {
+          parsed.add(port);
+        }
+      } catch (NumberFormatException ignored) {
+        // Silently skip malformed tokens, see javadoc above.
+      }
+    }
+    return parsed;
+  }
+
+  public void setAdditionalSelendroidServerPortsRaw(String value) {
+    this.additionalSelendroidServerPortsRaw = value;
   }
 
   public void addSupportedApp(String appAbsolutPath) {


### PR DESCRIPTION
Towards selendroid/selendroid#106.

## Why a foundational PR
Issue #106 tracks the broader work of letting selendroid host more than one app under test on a single device. The blocker today is that `SelendroidConfiguration` only owns a single `-selendroidServerPort`, so the rest of the codebase has no way to learn about additional ports the operator wants to allocate. Closing the runtime side of #106 needs follow-up changes inside `DeviceManager`, `ServerInstrumentation` and the CreateSession handler, but those changes need a stable configuration surface first.

## What this PR does
Adds a single additive command-line parameter, `-additionalSelendroidServerPorts`, that accepts a comma-separated list of additional ports plus a getter that returns the parsed view. Default value is the empty string, so any existing invocation of selendroid-standalone behaves identically to today.

```java
@Parameter(
    description = "comma-separated list of additional ports the standalone server may use "
        + "to host extra instrumentation servers in parallel. See issue #106 for context.",
    names = {"-additionalSelendroidServerPorts"})
private String additionalSelendroidServerPortsRaw = "";

public List<Integer> getAdditionalSelendroidServerPorts() {
    final List<Integer> parsed = new ArrayList<Integer>();
    if (additionalSelendroidServerPortsRaw == null
        || additionalSelendroidServerPortsRaw.trim().isEmpty()) {
        return parsed;
    }
    for (final String token : additionalSelendroidServerPortsRaw.split(",")) {
        ...
    }
    return parsed;
}
```

The parser is intentionally lenient: malformed tokens are silently skipped and ports outside the legal range or equal to the primary `-selendroidServerPort` are dropped, so a typo in the new flag never crashes standalone startup.

## What follow-up work still needs
- Teach `DeviceManager` to allocate one of these ports per active session.
- Update `CreateSessionHandler` to honour a per-session port choice.
- Document the new parameter in `selendroid.io`.

Each of those can be a small standalone PR layered on top of this configuration surface.

## Validation
- The diff only adds new fields and methods, no existing public API is altered.
- Default value is empty so unit tests that snapshot configuration output continue to match.
- Manual: invoking standalone with `-additionalSelendroidServerPorts 8081,8082,foo,99999` yields `[8081, 8082]` from the getter and ignores the bad tokens.
